### PR TITLE
rvm-install-system-wide URL is no longer valid

### DIFF
--- a/files/install-system-rvm
+++ b/files/install-system-rvm
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-bash < <( curl -s https://rvm.beginrescueend.com/install/rvm )

--- a/files/install-system-rvm
+++ b/files/install-system-rvm
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bash < <( curl -L http://bit.ly/rvm-install-system-wide )
+bash < <( curl -s https://rvm.beginrescueend.com/install/rvm )

--- a/manifests/classes/passenger.pp
+++ b/manifests/classes/passenger.pp
@@ -29,11 +29,7 @@ class rvm::passenger::apache(
     # Can we read the output of a command into a variable?
     # e.g. $gempath = `usr/local/bin/rvm ${ruby_version} exec rvm gemdir`
     $gempath = "${rvm_prefix}rvm/gems/${ruby_version}/gems"
-    $binpath = $rvm_prefix ? {
-        '/usr/local/' => '/usr/local/bin/',
-        default => "${rvm_prefix}rvm/bin/"
-    }
-
+    $binpath = "${rvm_prefix}rvm/bin/"
 
     # Dependencies
     if ! defined(Package['build-essential'])      { package { build-essential:      ensure => installed } }
@@ -80,13 +76,13 @@ class rvm::passenger::apache(
     }
 
     # Add Apache restart hooks
-    File['/etc/apache2/mods-available/passenger.load'] ~> Service['apache']
-    File['/etc/apache2/mods-available/passenger.conf'] ~> Service['apache']
-    File['/etc/apache2/mods-enabled/passenger.load']   ~> Service['apache']
-    File['/etc/apache2/mods-enabled/passenger.conf']   ~> Service['apache']
+    File['/etc/apache2/mods-available/passenger.load'] ~> Service['apache2']
+    File['/etc/apache2/mods-available/passenger.conf'] ~> Service['apache2']
+    File['/etc/apache2/mods-enabled/passenger.load']   ~> Service['apache2']
+    File['/etc/apache2/mods-enabled/passenger.conf']   ~> Service['apache2']
 }
 
-class ruby::passenger::apache::disable {
+class rvm::passenger::apache::disable {
 
     file {
         '/etc/apache2/mods-enabled/passenger.load':
@@ -96,6 +92,6 @@ class ruby::passenger::apache::disable {
     }
 
     # Add Apache restart hooks
-    if defined(Service['apache']) { File['/etc/apache2/mods-enabled/passenger.load']   ~> Service['apache'] }
-    if defined(Service['apache']) { File['/etc/apache2/mods-enabled/passenger.conf']   ~> Service['apache'] }
+    if defined(Service['apache2']) { File['/etc/apache2/mods-enabled/passenger.load']   ~> Service['apache2'] }
+    if defined(Service['apache2']) { File['/etc/apache2/mods-enabled/passenger.conf']   ~> Service['apache2'] }
 }

--- a/manifests/classes/system.pp
+++ b/manifests/classes/system.pp
@@ -2,21 +2,14 @@ class rvm::system {
 
   include rvm::dependencies
 
-  file {'install-system-rvm':
-    ensure => 'present',
-    path => '/root/install-system-rvm',
-    owner => 'root', group => 'root', mode => '0774',
-    source => 'puppet:///modules/rvm/install-system-rvm';
-  }
-
   exec { 'system-rvm':
-    command => '/root/install-system-rvm',
+    path    => '/usr/bin:/usr/sbin:/bin',
+    command => 'bash -c \'bash <(/usr/bin/curl -s https://rvm.beginrescueend.com/install/rvm)\'',
+    creates => '/usr/local/bin/rvm',
     require => [
-      File['install-system-rvm'],
       Package['curl', 'git-core'],
       Class['rvm::dependencies'],
     ],
-    creates => '/usr/local/bin/rvm';
   }
 
 }


### PR DESCRIPTION
I've replaced it with https://rvm.beginrescueend.com/install/rvm.  Thanks for a great rvm module - after days of searching this is the only one I've found that does what I need, and it's done very well.  Thank you!
