### PR TITLE
Add rvm_installed fact for wrpaping around rvm_system_ruby and rvm_gem resources, to avoid "default provider" error

### DIFF
--- a/lib/facter/rvm_installed.rb
+++ b/lib/facter/rvm_installed.rb
@@ -1,0 +1,7 @@
+Facter.add("rvm_installed") do
+  rvm_binary = "/usr/local/rvm/bin/rvm"
+
+  setcode do
+    File.exists? rvm_binary
+  end
+end


### PR DESCRIPTION
It's a bit of an ugly workaround, but it seems to work just fine for avoiding the default provider errors.
