### PR TITLE
Fully-qualified path for 'cat'

### DIFF
--- a/manifests/definitions/system_user.pp
+++ b/manifests/definitions/system_user.pp
@@ -7,7 +7,7 @@ define rvm::system_user () {
     }
 
     exec { "/usr/sbin/usermod -a -G $group $username":
-        unless => "cat /etc/group | grep $group | grep $username",
+        unless => "/usr/bin/cat /etc/group | grep $group | grep $username",
         require => [User[$username], Exec['system-rvm']];
     }
 }

--- a/manifests/definitions/system_user.pp
+++ b/manifests/definitions/system_user.pp
@@ -7,7 +7,7 @@ define rvm::system_user () {
     }
 
     exec { "/usr/sbin/usermod -a -G $group $username":
-        unless => "/usr/bin/cat /etc/group | grep $group | grep $username",
+        unless => "/bin/cat /etc/group | grep $group | grep $username",
         require => [User[$username], Exec['system-rvm']];
     }
 }


### PR DESCRIPTION
I'm probably just missing something about how to set up the global path, but I had to make this change to make it work.
