### PR TITLE
3 Tweaks - RedHat, specific rvm version, fixup for Ruby 1.8 in rvm_system_ruby.rb

### DIFF
--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -1,3 +1,11 @@
+# Backport :lines to 1.8 if necessary
+# See http://oreilly.com/ruby/excerpts/ruby-best-practices/writing-backward-compatible.html
+class String
+  unless "".respond_to?(:lines)
+    alias_method :lines, :to_a
+  end
+end
+
 Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   desc "Ruby RVM support."
 

--- a/manifests/classes/dependencies.pp
+++ b/manifests/classes/dependencies.pp
@@ -1,6 +1,6 @@
 class rvm::dependencies {
   case $operatingsystem {
     Ubuntu: { require rvm::dependencies::ubuntu }
-    CentOS: { require rvm::dependencies::centos }
+    CentOS,RedHat: { require rvm::dependencies::centos }
   }
 }

--- a/manifests/classes/passenger.pp
+++ b/manifests/classes/passenger.pp
@@ -11,7 +11,7 @@ class rvm::passenger::apache(
 
     case $operatingsystem {
       Ubuntu: { include rvm::passenger::apache::ubuntu::pre }
-      CentOS: { include rvm::passenger::apache::centos::pre }
+      CentOS,RedHat: { include rvm::passenger::apache::centos::pre }
     }
     
     class {
@@ -28,6 +28,6 @@ class rvm::passenger::apache(
 
     case $operatingsystem {
       Ubuntu: { include rvm::passenger::apache::ubuntu::post }
-      CentOS: { include rvm::passenger::apache::centos::post }
+      CentOS,RedHat: { include rvm::passenger::apache::centos::post }
     }
 }

--- a/manifests/classes/system.pp
+++ b/manifests/classes/system.pp
@@ -1,10 +1,10 @@
-class rvm::system {
+class rvm::system($version='latest') {
 
   include rvm::dependencies
 
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',
-    command => 'bash -c \'/usr/bin/curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man ./rvm-installer\'',
+    command => "bash -c '/usr/bin/curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man ./rvm-installer --version ${version}'",
     creates => '/usr/local/rvm/bin/rvm',
     require => [
       Class['rvm::dependencies'],


### PR DESCRIPTION
Hi,

This pull request contains three tweaks:
- Use the CentOS code for Red Hat too,
- Allow installaition of a specific rvm version -- like `class { 'rvm::system': version => '1.7.2' }`
- Add `:lines` method to String in Ruby 1.8 so rvm_system_ruby.rb will work in 1.8 as well as 1.9

Let me know if you'd prefer three separate pull requests
