### PR TITLE
Fix for Centos5 servers using stock ruby.

### DIFF
--- a/lib/puppet/provider/rvm_gemset/gemset.rb
+++ b/lib/puppet/provider/rvm_gemset/gemset.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:rvm_gemset).provide(:gemset) do
 
     command = gemsetcommand + ['list']
     output = execute(command)
-    output.lines do |line|
+    output.each do |line|
       if line =~ /^\s+\S+/
         list << line.strip
       end


### PR DESCRIPTION
Fix to allow the gemset provider to work properly on Centos 5 using site_ruby. Let me know if you would like me to tet this out on a few other platforms.

Thanks
