### PR TITLE
Update gem command

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
   end
 
   def gembinary
-    [command(:rvmcmd), ruby_version, "gem"]
+    [command(:rvmcmd), ruby_version, "do", "gem"]
   end
 
 


### PR DESCRIPTION
To avoid gemsplit breaking on the deprecation warning:
 "WARN: Please note that `rvm gem ...` is only an alias to `rvm do gem ...`,
 it might work different as in earlier versions of RVM and will be shortly removed!"
