### PR TITLE
Fix missing dependency for mod_ssl for RHEL/CentOS

### DIFF
--- a/manifests/classes/passenger-centos-pre.pp
+++ b/manifests/classes/passenger-centos-pre.pp
@@ -3,5 +3,6 @@ class rvm::passenger::apache::centos::pre {
   # Dependencies
   if ! defined(Package["httpd"]) { package { "httpd": ensure => installed } }
   if ! defined(Package["httpd-devel"]) { package { "httpd-devel":  ensure => installed } }
+  if ! defined(Package["mod_ssl"]) { package { "mod_ssl":  ensure => installed } }
 
 }


### PR DESCRIPTION
The commit is pretty simple; it just allows installing Passenger without having Package['mod_ssl'] defined, similar to the deps for httpd and httpd-devel.
