### PR TITLE
rvm doesn't like being called from a full path

### DIFF
--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   desc "Ruby RVM support."
 
-  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  commands :rvmcmd => "rvm"
 
   def create
     rvmcmd "install", resource[:name]


### PR DESCRIPTION
I kept getting this error during every puppet run:

notice: /Stage[main]//Node[test]/Server::Www[stable]/Rvm_system_ruby[ruby-1.9.2-p180]/default_use: default_use changed 'false' to 'true'

It looks like rvm doesn't like to be called using it's full path, and so the default was never getting set.

This seems to fix the issue, but I'm willing to bet that this change will cause some other issue.

Do you think this an ok change?
