### PR TITLE
Fixes problems in Ubuntu 11.10 (Oneiric)

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,7 +1,7 @@
-class rvm::system($version='latest', stage='rvm-install') {
+class rvm::system($version='latest', $a_stage='rvm-install') {
 
   include rvm
-  class {'rvm::dependencies': stage => $stage;}
+  class {'rvm::dependencies': stage => $a_stage;}
 
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',


### PR DESCRIPTION
I was seeing this errors, which prevents installing RVM.

Ubuntu 11.10 comes with puppet 2.7.1 and the problem seems to be triggered by the recent changes to support stages (note: I'm running puppet from the command line, no puppet master used).

  warning: Deprecation notice: must now include '$' in prototype on line 1 in file /etc/puppet/modules/rvm/manifests/system.pp
  warning: stage is a metaparam; this value will inherit to all contained resources
  Could not find stage main specified by Class[Rvm] at /etc/puppet/modules/rvm/manifests/system.pp:3 on node ip-10-50-63-22.eu-west-1.compute.internal
