### PR TITLE
Updates for rvm-rpm usage, selinux and other fixes

### DIFF
--- a/files/after_install
+++ b/files/after_install
@@ -3,22 +3,20 @@
 # This script will make sure the correct selinux contexts are set on ruby
 # files after each ruby version install.
 
-echo "Test hook executing"
-env | grep -i rvm
-
-if [ -x '/usr/sbin/semanage' -a -x '/sbin/restorecon' ]; then
-  echo "executables good"
-else
-  echo "executables bad"
+if [ ! ( -x '/usr/sbin/semanage' -a -x '/sbin/restorecon' ) ]; then
+  echo "SELinux executables missing, rvm after_install hook failed"
+  exit
 fi
 
-exit
-
-# Set up rvm file contexts if they are not already present
-if ! semanage fcontext -l | /bin/grep -q rvm; then
+# Set up rvm file context patterns if they are not already present
+# This will handle installs in either /usr/local/rvm or /usr/lib/rvm
+semanage fcontext -l | /bin/grep -q rvm; || {
   semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/wrappers(/.*)?'
   semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/rubies/ruby-.*/bin(/.*)?'
   semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/rubies/ruby-.*/lib(/.*)?'
   semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/gems(/.*)?'
   semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents(/.*)?'
-fi
+}
+
+# Run restorecon on the rvm hierarchy to fix the contexts
+restorecon -R $rvm_path

--- a/files/after_install
+++ b/files/after_install
@@ -15,7 +15,7 @@ semanage fcontext -l | /bin/grep -q rvm || {
   semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/rubies/ruby-.*/bin(/.*)?'
   semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/rubies/ruby-.*/lib(/.*)?'
   semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/gems(/.*)?'
-  semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents(/.*)?'
+  semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/(apache2/)?Passenger.*'
 }
 
 # Run restorecon on the rvm hierarchy to fix the contexts

--- a/files/after_install
+++ b/files/after_install
@@ -7,6 +7,11 @@
 # of rvm (now 1.10.2) such that it cannot find this after_install hook
 # See rvm issues #744 and #745 on github for more information
 
+if [ $EUID -ne 0 ]; then
+  # Don't try to mess with selinux if we are not root
+  exit
+fi
+
 if [ ! \( -x /usr/sbin/semanage -a -x /sbin/restorecon \) ]; then
   echo "SELinux executables missing, rvm after_install hook failed"
   exit 1

--- a/files/after_install
+++ b/files/after_install
@@ -3,9 +3,13 @@
 # This script will make sure the correct selinux contexts are set on ruby
 # files after each ruby version install.
 
+# WARNING - As of 2012-02-08, there is a bug in current versions
+# of rvm (now 1.10.2) such that it cannot find this after_install hook
+# See rvm issues #744 and #745 on github for more information
+
 if [ ! \( -x /usr/sbin/semanage -a -x /sbin/restorecon \) ]; then
   echo "SELinux executables missing, rvm after_install hook failed"
-  exit
+  exit 1
 fi
 
 # Set up rvm file context patterns if they are not already present

--- a/files/after_install
+++ b/files/after_install
@@ -3,7 +3,7 @@
 # This script will make sure the correct selinux contexts are set on ruby
 # files after each ruby version install.
 
-if [ ! ( -x '/usr/sbin/semanage' -a -x '/sbin/restorecon' ) ]; then
+if [ ! \( -x /usr/sbin/semanage -a -x /sbin/restorecon \) ]; then
   echo "SELinux executables missing, rvm after_install hook failed"
   exit
 fi

--- a/files/after_install
+++ b/files/after_install
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# rvm after_install hook to provide selinux support
+# This script will make sure the correct selinux contexts are set on ruby
+# files after each ruby version install.
+
+echo "Test hook executing"
+env | grep -i rvm
+
+if [ -x '/usr/sbin/semanage' -a -x '/sbin/restorecon' ]; then
+  echo "executables good"
+else
+  echo "executables bad"
+fi
+
+exit
+
+# Set up rvm file contexts if they are not already present
+if ! semanage fcontext -l | /bin/grep -q rvm; then
+  semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/wrappers(/.*)?'
+  semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/rubies/ruby-.*/bin(/.*)?'
+  semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/rubies/ruby-.*/lib(/.*)?'
+  semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/gems(/.*)?'
+  semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents(/.*)?'
+fi

--- a/files/after_install
+++ b/files/after_install
@@ -10,7 +10,7 @@ fi
 
 # Set up rvm file context patterns if they are not already present
 # This will handle installs in either /usr/local/rvm or /usr/lib/rvm
-semanage fcontext -l | /bin/grep -q rvm; || {
+semanage fcontext -l | /bin/grep -q rvm || {
   semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/wrappers(/.*)?'
   semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/rubies/ruby-.*/bin(/.*)?'
   semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/rubies/ruby-.*/lib(/.*)?'

--- a/lib/facter/rvm_installed.rb
+++ b/lib/facter/rvm_installed.rb
@@ -13,10 +13,8 @@ Facter.add(:rvm_binary) do
   setcode do
     [ '/usr/local/rvm/bin/rvm', '/usr/bin/rvm' ].each do |binfile|
       if File.exist?(binfile)
-        result = binfile
-        break
+        return binfile
       end
     end
-    result
   end
 end

--- a/lib/facter/rvm_installed.rb
+++ b/lib/facter/rvm_installed.rb
@@ -1,8 +1,21 @@
-Facter.add("rvm_installed") do
+Facter.add(:rvm_installed) do
   setcode do
     result = 'false'
     if File.exist?('/usr/local/rvm/bin/rvm') or File.exist?('/usr/bin/rvm')
       result = 'true'
+    end
+    result
+  end
+end
+
+Facter.add(:rvm_binary) do
+  confine :rvm_installed => :true
+  setcode do
+    [ '/usr/local/rvm/bin/rvm', '/usr/bin/rvm' ].each do |binfile|
+      if File.exist?(binfile)
+        result = binfile
+        break
+      end
     end
     result
   end

--- a/lib/facter/rvm_installed.rb
+++ b/lib/facter/rvm_installed.rb
@@ -1,7 +1,9 @@
 Facter.add("rvm_installed") do
-  rvm_binary = "/usr/local/rvm/bin/rvm"
-
   setcode do
-    File.exists? rvm_binary
+    result = 'false'
+    if File.exist?('/usr/local/rvm/bin/rvm') or File.exist?('/usr/bin/rvm')
+      result = 'true'
+    end
+    result
   end
 end

--- a/lib/facter/rvm_installed.rb
+++ b/lib/facter/rvm_installed.rb
@@ -11,10 +11,13 @@ end
 Facter.add(:rvm_binary) do
   confine :rvm_installed => :true
   setcode do
+    result = ''
     [ '/usr/local/rvm/bin/rvm', '/usr/bin/rvm' ].each do |binfile|
       if File.exist?(binfile)
-        return binfile
+        result = binfile
+        break
       end
     end
+    result
   end
 end

--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -5,7 +5,7 @@ require 'uri'
 Puppet::Type.type(:rvm_gem).provide(:gem) do
   desc "Ruby Gem support using RVM."
 
-  commands :rvmcmd => "rvm"
+  commands :rvmcmd => Facter.value(:rvm_binary)
 
 
   def ruby_version

--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -5,7 +5,7 @@ require 'uri'
 Puppet::Type.type(:rvm_gem).provide(:gem) do
   desc "Ruby Gem support using RVM."
 
-  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  commands :rvmcmd => "rvm"
 
 
   def ruby_version

--- a/lib/puppet/provider/rvm_gemset/gemset.rb
+++ b/lib/puppet/provider/rvm_gemset/gemset.rb
@@ -2,7 +2,7 @@
 Puppet::Type.type(:rvm_gemset).provide(:gemset) do
   desc "RVM gemset support."
 
-  commands :rvmcmd => "rvm"
+  commands :rvmcmd => Facter.value(:rvm_binary)
 
   def ruby_version
     resource[:ruby_version]

--- a/lib/puppet/provider/rvm_gemset/gemset.rb
+++ b/lib/puppet/provider/rvm_gemset/gemset.rb
@@ -2,7 +2,7 @@
 Puppet::Type.type(:rvm_gemset).provide(:gemset) do
   desc "RVM gemset support."
 
-  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  commands :rvmcmd => "rvm"
 
   def ruby_version
     resource[:ruby_version]

--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   desc "Ruby RVM support."
 
-  commands :rvmcmd => "rvm"
+  commands :rvmcmd => Facter.value(:rvm_binary)
 
   def create
     rvmcmd "install", resource[:name]

--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   desc "Ruby RVM support."
 
-  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  commands :rvmcmd => "rvm"
 
   def create
     rvmcmd "install", resource[:name]

--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -1,4 +1,13 @@
 class rvm::dependencies {
+  # Precreate the rvm group, otherwise the git installer fails to create it
+  # as a system group
+  if ! defined(Group['rvm']) {
+    group { 'rvm':
+      ensure => present,
+      system => true,
+    }
+  }
+
   case $operatingsystem {
     Ubuntu,Debian: { require rvm::dependencies::ubuntu }
     CentOS,RedHat: { require rvm::dependencies::centos }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -45,7 +45,7 @@ class rvm::dependencies::centos {
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerLoggingAgent' &&
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/apache2/PassengerHelperAgent'",
         refreshonly => true,
-        logoutput   => on_error,
+        logoutput   => on_failure,
         require     => Package['policycoreutils-python'],
     }
   }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -15,7 +15,6 @@ class rvm::dependencies::centos {
   if ! defined(Package['gettext-devel'])   { package { 'gettext-devel':   ensure => installed } }
   if ! defined(Package['wget'])            { package { 'wget':            ensure => installed } }
   if ! defined(Package['bzip2'])           { package { 'bzip2':           ensure => installed } }
-  if ! defined(Package['sendmail'])        { package { 'sendmail':        ensure => installed } }
   if ! defined(Package['mailx'])           { package { 'mailx':           ensure => installed } }
   if ! defined(Package['libxml2'])         { package { 'libxml2':         ensure => installed } }
   if ! defined(Package['libxml2-devel'])   { package { 'libxml2-devel':   ensure => installed } }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -44,10 +44,9 @@ class rvm::dependencies::centos {
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerWatchdog' &&
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerLoggingAgent' &&
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/apache2/PassengerHelperAgent'",
-      refreshonly => true,
-      logoutput   => on_failure,
-      require     => Package['policycoreutils-python'],
-      before      => Class['rvm::system'],
+      logoutput => on_failure,
+      require   => Package['policycoreutils-python'],
+      unless    => '/usr/sbin/semanage fcontext -l | /bin/grep -q rvm',
     }
   }
 }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -24,6 +24,7 @@ class rvm::dependencies::centos {
   if ! defined(Package['readline-devel'])  { package { 'readline-devel':  ensure => installed } }
   if ! defined(Package['patch'])           { package { 'patch':           ensure => installed } }
   if ! defined(Package['git'])             { package { 'git':             ensure => installed } }
+  if ! defined(Package['libyaml-devel'])   { package { 'libyaml-devel':   ensure => installed } }
 
   if $selinux == 'true' {
     # Make sure we have semanage and restorecon commands

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -43,8 +43,9 @@ class rvm::dependencies::centos {
         /usr/sbin/semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/ext/apache2(/.*)?' &&
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerWatchdog' &&
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerLoggingAgent' &&
-        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/apache2/PassengerHelperAgent'"
+        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/apache2/PassengerHelperAgent'",
         refreshonly => true,
+        logoutput   => on_error,
         require     => Package['policycoreutils-python'],
     }
   }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -24,4 +24,28 @@ class rvm::dependencies::centos {
   if ! defined(Package['readline-devel'])  { package { 'readline-devel':  ensure => installed } }
   if ! defined(Package['patch'])           { package { 'patch':           ensure => installed } }
   if ! defined(Package['git'])             { package { 'git':             ensure => installed } }
+
+  # If we have selinux, prepare to set the correct file contexts
+  # On RHEL6 with a current policy, these are automatic when passenger is
+  # installed in the system ruby gems directory, but the alternative rvm
+  # location means they don't get set correctly by the default policy
+  if $selinux == 'true' {
+    # Make sure we have the semanage command
+    if ! defined(Package['policycoreutils-python']) {
+      package { 'policycoreutils-python': ensure => present }
+    }
+
+    # Give rvm-managed files the right contexts
+    exec { 'rvm-selinux-contexts':
+      command =>
+        "/usr/sbin/semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/wrappers/ruby-.*' &&
+        /usr/sbin/semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/rubies/ruby-.*/bin(/.*)?' &&
+        /usr/sbin/semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/ext/apache2(/.*)?' &&
+        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerWatchdog' &&
+        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerLoggingAgent' &&
+        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/apache2/PassengerHelperAgent'"
+        refreshonly => true,
+        require     => Package['policycoreutils-python'],
+    }
+  }
 }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -25,28 +25,10 @@ class rvm::dependencies::centos {
   if ! defined(Package['patch'])           { package { 'patch':           ensure => installed } }
   if ! defined(Package['git'])             { package { 'git':             ensure => installed } }
 
-  # If we have selinux, prepare to set the correct file contexts
-  # On RHEL6 with a current policy, these are automatic when passenger is
-  # installed in the system ruby gems directory, but the alternative rvm
-  # location means they don't get set correctly by the default policy
   if $selinux == 'true' {
     # Make sure we have semanage and restorecon commands
     if ! defined(Package['policycoreutils-python']) {
       package { 'policycoreutils-python': ensure => present }
-    }
-
-    # Install a hook into rvm to correct contexts after ruby installs
-    file { [ '/root/.rvm', '/root/.rvm/hooks' ]:
-      ensure => directory,
-      owner  => root,
-      group  => 0,
-      mode   => 0755,
-    }
-    file { '/root/.rvm/hooks/after_install':
-      source => 'puppet:///modules/rvm/after_install',
-      owner   => root,
-      group   => 0,
-      mode    => 0755,
     }
   }
 }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -6,7 +6,7 @@ class rvm::dependencies::centos {
   if ! defined(Package['make'])            { package { 'make':            ensure => installed } }
   if ! defined(Package['gettext-devel'])   { package { 'gettext-devel':   ensure => installed } }
   if ! defined(Package['expat-devel'])     { package { 'expat-devel':     ensure => installed } }
-  if ! defined(Package['curl-devel'])      { package { 'curl-devel':      ensure => installed } }
+  if ! defined(Package['libcurl-devel'])   { package { 'libcurl-devel':   ensure => installed } }
   if ! defined(Package['zlib-devel'])      { package { 'zlib-devel':      ensure => installed } }
   if ! defined(Package['openssl-devel'])   { package { 'openssl-devel':   ensure => installed } }
   if ! defined(Package['perl'])            { package { 'perl':            ensure => installed } }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -36,14 +36,13 @@ class rvm::dependencies::centos {
     }
 
     # Give rvm-managed files the right contexts
-    exec { 'rvm-selinux-contexts':
+    exec { 'selinux-contexts':
       command =>
-        "/usr/sbin/semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/wrappers/ruby-.*' &&
+        "/usr/sbin/semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/wrappers(/.*)?' &&
         /usr/sbin/semanage fcontext -a -t bin_t '/usr/(local|lib)/rvm/rubies/ruby-.*/bin(/.*)?' &&
-        /usr/sbin/semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/ext/apache2(/.*)?' &&
-        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerWatchdog' &&
-        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerLoggingAgent' &&
-        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/apache2/PassengerHelperAgent'",
+        /usr/sbin/semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/rubies/ruby-.*/lib(/.*)?' &&
+        /usr/sbin/semanage fcontext -a -t lib_t '/usr/(local|lib)/rvm/gems(/.*)?' &&
+        /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents(/.*)?'",
       logoutput => on_failure,
       require   => Package['policycoreutils-python'],
       unless    => '/usr/sbin/semanage fcontext -l | /bin/grep -q rvm',

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -36,7 +36,7 @@ class rvm::dependencies::centos {
     }
 
     # Install a hook into rvm to correct contexts after ruby installs
-    file { '/root/.rvm/hooks':
+    file { [ '/root/.rvm', '/root/.rvm/hooks' ]:
       ensure => directory,
       owner  => root,
       group  => 0,

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -44,9 +44,10 @@ class rvm::dependencies::centos {
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerWatchdog' &&
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/PassengerLoggingAgent' &&
         /usr/sbin/semanage fcontext -a -t passenger_exec_t '/usr/(local|lib)/rvm/gems/ruby-.*/gems/passenger-.*/agents/apache2/PassengerHelperAgent'",
-        refreshonly => true,
-        logoutput   => on_failure,
-        require     => Package['policycoreutils-python'],
+      refreshonly => true,
+      logoutput   => on_failure,
+      require     => Package['policycoreutils-python'],
+      before      => Class['rvm::system'],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 class rvm(
   $version = 'latest',
   $install_rvm = true,
-  $use_rpm = false,
+  $use_pkg = false,
   $rstage = 'rvm-install'
 ) {
   stage { 'rvm-install': before => Stage['main'] }
@@ -12,7 +12,7 @@ class rvm(
       'rvm::system':
         stage   => $rstage,
         version => $version,
-        use_rpm => $use_rpm;
+        use_pkg => $use_pkg;
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,13 @@
-class rvm($version='latest', $install_rvm=true) {
+class rvm($version='latest', $install_rvm=true, $use_rpm=false) {
   stage { 'rvm-install': before => Stage['main'] }
 
   if $install_rvm {
     class {
       'rvm::dependencies': stage => 'rvm-install';
-      'rvm::system':       stage => 'rvm-install', version => $version;
+      'rvm::system':
+        stage   => 'rvm-install',
+        version => $version,
+        use_rpm => $use_rpm;
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,16 @@
-class rvm($version='latest', $install_rvm=true, $use_rpm=false) {
+class rvm(
+  $version = 'latest',
+  $install_rvm = true,
+  $use_rpm = false,
+  $rstage = 'rvm-install'
+) {
   stage { 'rvm-install': before => Stage['main'] }
 
   if $install_rvm {
     class {
-      'rvm::dependencies': stage => 'rvm-install';
+      'rvm::dependencies': stage => $rstage;
       'rvm::system':
-        stage   => 'rvm-install',
+        stage   => $rstage,
         version => $version,
         use_rpm => $use_rpm;
     }

--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -29,7 +29,6 @@ class rvm::passenger::apache(
       class { 'rvm::passenger::apache::ubuntu::post':
         ruby_version       => $ruby_version,
         version            => $version,
-        rvm_prefix         => $rvm_prefix,
         mininstances       => $mininstances,
         maxpoolsize        => $maxpoolsize,
         poolidletime       => $poolidletime,
@@ -42,7 +41,6 @@ class rvm::passenger::apache(
       class { 'rvm::passenger::apache::centos::post':
         ruby_version       => $ruby_version,
         version            => $version,
-        rvm_prefix         => $rvm_prefix,
         mininstances       => $mininstances,
         maxpoolsize        => $maxpoolsize,
         poolidletime       => $poolidletime,

--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -1,7 +1,6 @@
 class rvm::passenger::apache(
   $ruby_version,
   $version,
-  $rvm_prefix = '/usr/local/',
   $mininstances = '1',
   $maxpoolsize = '6',
   $poolidletime = '300',
@@ -23,8 +22,7 @@ class rvm::passenger::apache(
   # TODO: How can we get the gempath automatically using the ruby version
   # Can we read the output of a command into a variable?
   # e.g. $gempath = `usr/local/rvm/bin/rvm ${ruby_version} exec rvm gemdir`
-  $gempath = "${rvm_prefix}rvm/gems/${ruby_version}/gems"
-  $binpath = "${rvm_prefix}rvm/bin/"
+  $gempath = "${rvm::system::rvmpath}/gems/${ruby_version}/gems"
 
   case $operatingsystem {
     Ubuntu: {
@@ -38,7 +36,6 @@ class rvm::passenger::apache(
         maxinstancesperapp => $maxinstancesperapp,
         spawnmethod        => $spawnmethod,
         gempath            => $gempath,
-        binpath            => $binpath;
       }
     }
     CentOS,RedHat: {
@@ -52,7 +49,6 @@ class rvm::passenger::apache(
         maxinstancesperapp => $maxinstancesperapp,
         spawnmethod        => $spawnmethod,
         gempath            => $gempath,
-        binpath            => $binpath;
       }
     }
   }

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -6,7 +6,7 @@ class rvm::passenger::apache::centos::post(
   $poolidletime = '300',
   $maxinstancesperapp = '0',
   $spawnmethod = 'smart-lv2',
-  $rvmpath = ${rvm::system::rvmpath},
+  $rvmpath = $rvm::system::rvmpath,
   $gempath
 ) {
   exec {

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -9,11 +9,35 @@ class rvm::passenger::apache::centos::post(
   $rvmpath = $rvm::system::rvmpath,
   $gempath
 ) {
+
+  $passdir = "${gempath}/passenger-${version}"
+
   exec { 'passenger-install-apache2-module':
     command   => "$rvm_binary ${ruby_version} exec passenger-install-apache2-module -a",
-    creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
+    creates   => "$passdir/ext/apache2/mod_passenger.so",
     logoutput => 'on_failure',
     require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
+  }
+
+  # Fix selinux file contexts
+  # On RHEL6 with a current policy, these are automatic when passenger is
+  # installed in the system ruby gems directory, but the nonstandard rvm
+  # location means they don't get set correctly by the default policy
+  if $selinux == 'true' {
+    file { "$passdir/ext/apache2/mod_passenger.so":
+      seltype => 'lib_t',
+      require => Exec['passenger-install-apache2-module'],
+      before  => File['/etc/httpd/conf.d/passenger.conf'],
+    }
+    file { [
+      "$passdir/agents/PassengerLoggingAgent",
+      "$passdir/agents/PassengerWatchdog",
+      "$passdir/agents/apache2/PassengerHelperAgent"
+    ]:
+      seltype => 'passenger_exec_t',
+      require => Exec['passenger-install-apache2-module'],
+      before  => File['/etc/httpd/conf.d/passenger.conf'],
+    }
   }
 
   file { '/etc/httpd/conf.d/passenger.conf':

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -9,18 +9,19 @@ class rvm::passenger::apache::centos::post(
   $rvmpath = $rvm::system::rvmpath,
   $gempath
 ) {
-  exec {
-    'passenger-install-apache2-module':
-      command   => "$rvm_binary ${rvm::passenger::apache::ruby_version} exec passenger-install-apache2-module -a",
-      creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
-      logoutput => 'on_failure',
-      require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
+  exec { 'passenger-install-apache2-module':
+    command   => "$rvm_binary ${ruby_version} exec passenger-install-apache2-module -a",
+    creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
+    logoutput => 'on_failure',
+    require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
   }
 
-  file {
-    '/etc/httpd/conf.d/passenger.conf':
-      ensure  => file,
-      content => template('rvm/passenger-apache-centos.conf.erb'),
-      require => Exec['passenger-install-apache2-module'];
+  file { '/etc/httpd/conf.d/passenger.conf':
+    content => template('rvm/passenger-apache-centos.conf.erb'),
+    require => Exec['passenger-install-apache2-module'];
+  }
+
+  if defined(Service['httpd']) {
+    File['/etc/httpd/conf.d/passenger.conf'] ~> Service['httpd']
   }
 }

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -17,6 +17,15 @@ class rvm::passenger::apache::centos::post(
     require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
   }
 
+  if $selinux == 'true' {
+    exec { 'passenger-contexts':
+      command     => "/sbin/restorecon -R $rvmpath",
+      refreshonly => true,
+      subscribe   => Exec['passenger-install-apache2-module'],
+      before      => File['/etc/httpd/conf.d/passenger.conf'],
+    }
+  }
+
   file { '/etc/httpd/conf.d/passenger.conf':
     content => template('rvm/passenger-apache-centos.conf.erb'),
     require => Exec['passenger-install-apache2-module'];

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -1,19 +1,18 @@
 class rvm::passenger::apache::centos::post(
   $ruby_version,
   $version,
-  $rvm_prefix = '/usr/local/',
   $mininstances = '1',
   $maxpoolsize = '6',
   $poolidletime = '300',
   $maxinstancesperapp = '0',
   $spawnmethod = 'smart-lv2',
-  $gempath,
-  $binpath
+  $rvmpath = ${rvm::system::rvmpath},
+  $gempath
 ) {
   exec {
     'passenger-install-apache2-module':
-      command   => "${rvm::passenger::apache::binpath}rvm ${rvm::passenger::apache::ruby_version} exec passenger-install-apache2-module -a",
-      creates   => "${rvm::passenger::apache::gempath}/passenger-${rvm::passenger::apache::version}/ext/apache2/mod_passenger.so",
+      command   => "${rvm::system::binpath}/rvm ${rvm::passenger::apache::ruby_version} exec passenger-install-apache2-module -a",
+      creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
       logoutput => 'on_failure',
       require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
   }

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -24,9 +24,18 @@ class rvm::passenger::apache::centos::post(
   # installed in the system ruby gems directory, but the nonstandard rvm
   # location means they don't get set correctly by the default policy
   if $selinux == 'true' {
-    file { "$passdir/ext/apache2/mod_passenger.so":
-      seltype => 'lib_t',
+    file { "$rvmpath/wrappers":
+      ensure  => directory,
+      recurse => true,
+      group   => 'rvm',
       mode    => 0755,
+      seltype => 'bin_t',
+      before  => File['/etc/httpd/conf.d/passenger.conf'],
+    }
+    file { "$passdir/ext/apache2/mod_passenger.so":
+      group   => 'rvm',
+      mode    => 0755,
+      seltype => 'lib_t',
       require => Exec['passenger-install-apache2-module'],
       before  => File['/etc/httpd/conf.d/passenger.conf'],
     }
@@ -35,8 +44,9 @@ class rvm::passenger::apache::centos::post(
       "$passdir/agents/PassengerWatchdog",
       "$passdir/agents/apache2/PassengerHelperAgent"
     ]:
-      seltype => 'passenger_exec_t',
+      group   => 'rvm',
       mode    => 0755,
+      seltype => 'passenger_exec_t',
       require => Exec['passenger-install-apache2-module'],
       before  => File['/etc/httpd/conf.d/passenger.conf'],
     }

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -11,7 +11,7 @@ class rvm::passenger::apache::centos::post(
 ) {
   exec {
     'passenger-install-apache2-module':
-      command   => "${rvm::system::binpath}/rvm ${rvm::passenger::apache::ruby_version} exec passenger-install-apache2-module -a",
+      command   => "$rvm_binary ${rvm::passenger::apache::ruby_version} exec passenger-install-apache2-module -a",
       creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
       logoutput => 'on_failure',
       require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -26,6 +26,7 @@ class rvm::passenger::apache::centos::post(
   if $selinux == 'true' {
     file { "$passdir/ext/apache2/mod_passenger.so":
       seltype => 'lib_t',
+      mode    => 0755,
       require => Exec['passenger-install-apache2-module'],
       before  => File['/etc/httpd/conf.d/passenger.conf'],
     }
@@ -35,6 +36,7 @@ class rvm::passenger::apache::centos::post(
       "$passdir/agents/apache2/PassengerHelperAgent"
     ]:
       seltype => 'passenger_exec_t',
+      mode    => 0755,
       require => Exec['passenger-install-apache2-module'],
       before  => File['/etc/httpd/conf.d/passenger.conf'],
     }

--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -10,46 +10,11 @@ class rvm::passenger::apache::centos::post(
   $gempath
 ) {
 
-  $passdir = "${gempath}/passenger-${version}"
-
   exec { 'passenger-install-apache2-module':
-    command   => "$rvm_binary ${ruby_version} exec passenger-install-apache2-module -a",
-    creates   => "$passdir/ext/apache2/mod_passenger.so",
+    command   => "$rvm_binary $ruby_version exec passenger-install-apache2-module -a",
+    creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
     logoutput => 'on_failure',
     require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
-  }
-
-  # Fix selinux file contexts
-  # On RHEL6 with a current policy, these are automatic when passenger is
-  # installed in the system ruby gems directory, but the nonstandard rvm
-  # location means they don't get set correctly by the default policy
-  if $selinux == 'true' {
-    file { "$rvmpath/wrappers":
-      ensure  => directory,
-      recurse => true,
-      group   => 'rvm',
-      mode    => 0755,
-      seltype => 'bin_t',
-      before  => File['/etc/httpd/conf.d/passenger.conf'],
-    }
-    file { "$passdir/ext/apache2/mod_passenger.so":
-      group   => 'rvm',
-      mode    => 0755,
-      seltype => 'lib_t',
-      require => Exec['passenger-install-apache2-module'],
-      before  => File['/etc/httpd/conf.d/passenger.conf'],
-    }
-    file { [
-      "$passdir/agents/PassengerLoggingAgent",
-      "$passdir/agents/PassengerWatchdog",
-      "$passdir/agents/apache2/PassengerHelperAgent"
-    ]:
-      group   => 'rvm',
-      mode    => 0755,
-      seltype => 'passenger_exec_t',
-      require => Exec['passenger-install-apache2-module'],
-      before  => File['/etc/httpd/conf.d/passenger.conf'],
-    }
   }
 
   file { '/etc/httpd/conf.d/passenger.conf':

--- a/manifests/passenger/apache/centos/pre.pp
+++ b/manifests/passenger/apache/centos/pre.pp
@@ -11,12 +11,4 @@ class rvm::passenger::apache::centos::pre {
     group  => 0,
     mode   => 0755,
   }
-
-  if $selinux == 'true' {
-    # Allows apache/passenger to adjust its file descriptor limits
-    selboolean { 'httpd_setrlimit':
-      value      => on,
-      persistent => true,
-    }
-  }
 }

--- a/manifests/passenger/apache/centos/pre.pp
+++ b/manifests/passenger/apache/centos/pre.pp
@@ -3,4 +3,20 @@ class rvm::passenger::apache::centos::pre {
   if ! defined(Package['httpd'])       { package { 'httpd':       ensure => installed } }
   if ! defined(Package['httpd-devel']) { package { 'httpd-devel': ensure => installed } }
   if ! defined(Package['mod_ssl'])     { package { 'mod_ssl':     ensure => installed } }
+
+  # Using this temp directory makes passenger work better with selinux
+  file { '/var/run/passenger':
+    ensure => directory,
+    owner  => root,
+    group  => 0,
+    mode   => 0755,
+  }
+
+  if $selinux == 'true' {
+    # Allows apache/passenger to adjust its file descriptor limits
+    selboolean { 'httpd_setrlimit':
+      value      => on,
+      persistent => true,
+    }
+  }
 }

--- a/manifests/passenger/apache/ubuntu/post.pp
+++ b/manifests/passenger/apache/ubuntu/post.pp
@@ -12,7 +12,7 @@ class rvm::passenger::apache::ubuntu::post(
 
   exec {
     'passenger-install-apache2-module':
-      command   => "${rvm::system::binpath}/rvm ${ruby_version} exec passenger-install-apache2-module -a",
+      command   => "$rvm_binary ${ruby_version} exec passenger-install-apache2-module -a",
       creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
       logoutput => 'on_failure',
       require   => [Rvm_gem['passenger'], Package['apache2', 'build-essential', 'apache2-prefork-dev',

--- a/manifests/passenger/apache/ubuntu/post.pp
+++ b/manifests/passenger/apache/ubuntu/post.pp
@@ -1,19 +1,18 @@
 class rvm::passenger::apache::ubuntu::post(
   $ruby_version,
   $version,
-  $rvm_prefix = '/usr/local/',
   $mininstances = '1',
   $maxpoolsize = '6',
   $poolidletime = '300',
   $maxinstancesperapp = '0',
   $spawnmethod = 'smart-lv2',
-  $gempath,
-  $binpath
+  $rvmpath = ${rvm::system::rvmpath},
+  $gempath
 ) {
 
   exec {
     'passenger-install-apache2-module':
-      command   => "${binpath}rvm ${ruby_version} exec passenger-install-apache2-module -a",
+      command   => "${rvm::system::binpath}/rvm ${ruby_version} exec passenger-install-apache2-module -a",
       creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
       logoutput => 'on_failure',
       require   => [Rvm_gem['passenger'], Package['apache2', 'build-essential', 'apache2-prefork-dev',

--- a/manifests/passenger/apache/ubuntu/post.pp
+++ b/manifests/passenger/apache/ubuntu/post.pp
@@ -6,7 +6,7 @@ class rvm::passenger::apache::ubuntu::post(
   $poolidletime = '300',
   $maxinstancesperapp = '0',
   $spawnmethod = 'smart-lv2',
-  $rvmpath = ${rvm::system::rvmpath},
+  $rvmpath = $rvm::system::rvmpath,
   $gempath
 ) {
 

--- a/manifests/passenger/gem.pp
+++ b/manifests/passenger/gem.pp
@@ -3,6 +3,6 @@ class rvm::passenger::gem($ruby_version, $version) {
     "passenger":
       ensure       => $version,
       ruby_version => $ruby_version,
-      require      => Rvm_system_ruby["ruby-${ruby_version}"],
+      require      => Rvm_system_ruby["${ruby_version}"],
   }
 }

--- a/manifests/passenger/gem.pp
+++ b/manifests/passenger/gem.pp
@@ -5,4 +5,11 @@ class rvm::passenger::gem($ruby_version, $version) {
       ruby_version => $ruby_version,
       require      => Rvm_system_ruby["${ruby_version}"],
   }
+  if $selinux == 'true' {
+    exec { 'passenger-contexts':
+      command     => "/sbin/restorecon -R $rvm::system::rvmpath",
+      refreshonly => true,
+      subscribe   => Rvm_gem['passenger'],
+    }
+  }
 }

--- a/manifests/passenger/gem.pp
+++ b/manifests/passenger/gem.pp
@@ -1,7 +1,8 @@
 class rvm::passenger::gem($ruby_version, $version) {
   rvm_gem {
     "passenger":
-      ensure => $version,
+      ensure       => $version,
       ruby_version => $ruby_version,
+      require      => Rvm_system_ruby["ruby-${ruby_version}"],
   }
 }

--- a/manifests/passenger/gem.pp
+++ b/manifests/passenger/gem.pp
@@ -5,11 +5,4 @@ class rvm::passenger::gem($ruby_version, $version) {
       ruby_version => $ruby_version,
       require      => Rvm_system_ruby["${ruby_version}"],
   }
-  if $selinux == 'true' {
-    exec { 'passenger-contexts':
-      command     => "/sbin/restorecon -R $rvm::system::rvmpath",
-      refreshonly => true,
-      subscribe   => Rvm_gem['passenger'],
-    }
-  }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,7 +1,7 @@
 class rvm::system(
-  $version='latest',
-  $depstage='rvm-install',
-  $use_rpm=false
+  $version = 'latest',
+  $depstage = 'rvm-install',
+  $use_rpm = false
 ) {
 
   include rvm

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,17 +1,34 @@
-class rvm::system($version='latest', stage='rvm-install') {
+class rvm::system(
+  $version='latest',
+  $stage='rvm-install',
+  $use_rpm=false
+) {
 
   include rvm
   class {'rvm::dependencies': stage => $stage;}
 
-  exec { 'system-rvm':
-    path    => '/usr/bin:/usr/sbin:/bin',
-    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer ;
-                chmod +x /tmp/rvm-installer ;
-                rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${version} ;
-                rm /tmp/rvm-installer'",
-    creates => '/usr/local/rvm/bin/rvm',
-    require => [
-      Class['rvm::dependencies'],
-    ],
+  # If you set $use_rpm to true, then this module expects that you have made
+  # the rvm-ruby RPM available in some yum repository
+  # https://github.com/mdkent/rvm-rpm
+  if ($use_rpm) {
+    $rvmpath = '/usr/lib/rvm'
+    $binpath = '/usr/bin'
+    package { 'rvm-ruby':
+      ensure  => $version,
+      require => Class['rvm::dependencies'],
+    }
+  }
+  else {
+    $rvmpath = '/usr/local/rvm'
+    $binpath = "${rvmpath}/bin"
+    exec { 'system-rvm':
+      path    => '/usr/bin:/usr/sbin:/bin',
+      command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer ;
+                  chmod +x /tmp/rvm-installer ;
+                  rvm_bin_path=${binpath} rvm_man_path=${rvmpath}/man /tmp/rvm-installer --version ${version} ;
+                  rm /tmp/rvm-installer'",
+      creates => "${binpath}/rvm",
+      require => Class['rvm::dependencies'],
+    }
   }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -12,7 +12,6 @@ class rvm::system(
   # https://github.com/mdkent/rvm-rpm
   if ($use_rpm) {
     $rvmpath = '/usr/lib/rvm'
-    $binpath = '/usr/bin'
     package { 'rvm-ruby':
       ensure  => $version,
       require => Class['rvm::dependencies'],
@@ -20,14 +19,13 @@ class rvm::system(
   }
   else {
     $rvmpath = '/usr/local/rvm'
-    $binpath = "${rvmpath}/bin"
     exec { 'system-rvm':
       path    => '/usr/bin:/usr/sbin:/bin',
       command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer ;
                   chmod +x /tmp/rvm-installer ;
-                  rvm_bin_path=${binpath} rvm_man_path=${rvmpath}/man /tmp/rvm-installer --version ${version} ;
+                  rvm_path=${rvmpath} /tmp/rvm-installer --version ${version} ;
                   rm /tmp/rvm-installer'",
-      creates => "${binpath}/rvm",
+      creates => "${rvmpath}/bin/rvm",
       require => Class['rvm::dependencies'],
     }
   }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,11 +1,11 @@
 class rvm::system(
   $version='latest',
-  $stage='rvm-install',
+  $depstage='rvm-install',
   $use_rpm=false
 ) {
 
   include rvm
-  class {'rvm::dependencies': stage => $stage;}
+  class {'rvm::dependencies': stage => $depstage;}
 
   # If you set $use_rpm to true, then this module expects that you have made
   # the rvm-ruby RPM available in some yum repository

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,8 +1,8 @@
-class rvm::system($version = 'latest', $use_rpm = false) {
-  # If you set $use_rpm to true, then this module expects that you have made
-  # the rvm-ruby RPM available in some yum repository
-  # https://github.com/mdkent/rvm-rpm
-  if ($use_rpm) {
+class rvm::system($version = 'latest', $use_pkg = false) {
+  # If you set $use_pkg to true, then this module expects that you have made
+  # an rvm-ruby package available in some repository
+  # One source for this package is https://github.com/mdkent/rvm-rpm
+  if ($use_pkg) {
     $rvmpath = '/usr/lib/rvm'
     package { 'rvm-ruby':
       ensure  => $version,
@@ -29,7 +29,7 @@ class rvm::system($version = 'latest', $use_rpm = false) {
       owner   => root,
       group   => 'rvm',
       mode    => 0755,
-      require => $use_rpm ? {
+      require => $use_pkg ? {
         true  => Package['rvm-ruby'],
         false => Exec['system-rvm'],
       },

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -29,16 +29,4 @@ class rvm::system(
       require => Class['rvm::dependencies'],
     }
   }
-
-  # Set correct contexts on files if we have selinux
-  if $selinux == 'true' {
-    exec { 'selinux-restorecon':
-      command     => "/sbin/restorecon -R $rvmpath",
-      refreshonly => true,
-      subscribe   => $use_rpm ? {
-        true  => Package['rvm-ruby'],
-        false => Exec['system-rvm'],
-      },
-    }
-  }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -29,4 +29,18 @@ class rvm::system(
       require => Class['rvm::dependencies'],
     }
   }
+
+  # Install the rvm hook to set selinux file contexts if needed
+  if $selinux == 'true' {
+    file { "$rvmpath/hooks/after_install":
+      source  => 'puppet:///modules/rvm/after_install',
+      owner   => root,
+      group   => 'rvm',
+      mode    => 0755,
+      require => $use_rpm ? {
+        true  => Package['rvm-ruby'],
+        false => Exec['system-rvm'],
+      },
+    }
+  }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -29,4 +29,16 @@ class rvm::system(
       require => Class['rvm::dependencies'],
     }
   }
+
+  # Set correct contexts on files if we have selinux
+  if $selinux == 'true' {
+    exec { 'selinux-restorecon':
+      command     => "/sbin/restorecon -R $rvmpath",
+      refreshonly => true,
+      subscribe   => $use_rpm ? {
+        true  => Package['rvm-ruby'],
+        false => Exec['system-rvm'],
+      },
+    }
+  }
 }

--- a/manifests/system_user.pp
+++ b/manifests/system_user.pp
@@ -7,18 +7,19 @@ define rvm::system_user () {
 
   if ! defined(User[$username]) {
     user { $username:
-      ensure => present;
+      ensure => present,
     }
   }
 
   if ! defined(Group[$group]) {
     group { $group:
-      ensure => present;
+      ensure => present,
+      system => true,
     }
   }
 
   exec { "/usr/sbin/usermod -a -G $group $username":
     unless  => "/bin/cat /etc/group | grep $group | grep $username",
-    require => [User[$username], Group[$group]];
+    require => [User[$username], Group[$group]],
   }
 }

--- a/manifests/system_user.pp
+++ b/manifests/system_user.pp
@@ -11,13 +11,6 @@ define rvm::system_user () {
     }
   }
 
-  if ! defined(Group[$group]) {
-    group { $group:
-      ensure => present,
-      system => true,
-    }
-  }
-
   exec { "/usr/sbin/usermod -a -G $group $username":
     unless  => "/bin/cat /etc/group | grep $group | grep $username",
     require => [User[$username], Group[$group]],

--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -8,4 +8,5 @@ LoadModule passenger_module <%= gempath %>/passenger-<%= version %>/ext/apache2/
   PassengerMinInstances <%= mininstances %>
   PassengerMaxInstancesPerApp <%= maxinstancesperapp %>
   PassengerSpawnMethod <%= spawnmethod %>
+  PassengerTempDir /var/run/passenger
 </IfModule>

--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -2,7 +2,7 @@ LoadModule passenger_module <%= gempath %>/passenger-<%= version %>/ext/apache2/
 
 <IfModule passenger_module>
   PassengerRoot <%= gempath %>/passenger-<%= version %>
-  PassengerRuby <%= rvm_prefix %>rvm/wrappers/<%= ruby_version %>/ruby
+  PassengerRuby <%= rvmpath %>/wrappers/<%= ruby_version %>/ruby
   PassengerMaxPoolSize <%= maxpoolsize %>
   PassengerPoolIdleTime <%= poolidletime %>
   PassengerMinInstances <%= mininstances %>

--- a/templates/passenger-apache.conf.erb
+++ b/templates/passenger-apache.conf.erb
@@ -1,6 +1,6 @@
 <IfModule passenger_module>
   PassengerRoot <%= gempath %>/passenger-<%= version %>
-  PassengerRuby <%= rvm_prefix %>rvm/wrappers/<%= ruby_version %>/ruby
+  PassengerRuby <%= rvmpath %>/wrappers/<%= ruby_version %>/ruby
   PassengerMaxPoolSize <%= maxpoolsize %>
   PassengerPoolIdleTime <%= poolidletime %>
   PassengerMinInstances <%= mininstances %>


### PR DESCRIPTION
As promised, here are the updates for compatibility with RPM installs as well as adding selinux support for Redhat-ish systems.  My apologies for the number of commits, I was experimenting with the best way to do things along the way.

The first requirement for RPM support was to make the whole thing independent of the rvm install location.  In order to accomplish this, I created a new fact called rvm_binary which points to the rvm executable.  Both the manifests and providers make use of this fact.  Also, the variable $rvm::system::rvmpath contains the rvm installation path, normally /usr/local/rvm for a script install or /usr/lib/rvm for the RPM install.  To get the packaged install, you set the use_pkg class parameter to true.

The other major bit is selinux support.  This is conditional on the selinux fact, which will be true on selinux-enabled systems.  The main part of this is accomplished by adding an after_install hook to rvm, which runs every time a ruby version is installed.  It will adjust the selinux file contexts on the ruby directories.  Also, there's an extra exec when building passenger, since the Apache-related executables need some special contexts.  Note that I found a bug in rvm hooks along the way, see issues 744-745 on rvm for info.

This has all been tested on RHEL6.  I have no Ubuntu systems so I would greatly appreciate it if you make sure I didn't break Ubuntu, and I'd more than welcome any other feedback/discussion on the changes.  Thanks for providing this very helpful module!
