### PR TITLE
Install script bug fix

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,9 +1,9 @@
 class rvm::system($version='latest') {
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',
-    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer ;
-                chmod +x /tmp/rvm-installer ;
-                rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${version} ;
+    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer ; \
+                chmod +x /tmp/rvm-installer ; \
+                rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${version} ; \
                 rm /tmp/rvm-installer'",
     creates => '/usr/local/rvm/bin/rvm',
     require => [


### PR DESCRIPTION
Puppet was crashing when running the install script contained in system.pp.

I've added \ characters at the end of each line in the command and this has resolved my issue.
