### PR TITLE
Workaround Puppets late binding issue for resources by Being Clever(TM)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,9 +6,8 @@ as root) and using it to install rubies and gems.  Support for installing and
 configuring passenger is also included.
 
 We are actively using this module.  It works well, but does have some issues you
-should be aware of.  Due to the way puppet works, certain resources
-(rvm\_sytem\_ruby, rvm\_gem and rvm\_gemset) may generate errors until RVM is
-installed.  The puppet-rvm module uses run stages to install RVM before the rest
+should be aware of.  
+The puppet-rvm module uses run stages to install RVM before the rest
 of your configuration runs.  However, if you run puppet using the `--noop`
 parameter, you may see _Could not find a default provider_ errors.  See the
 Troubleshooting section for more information.
@@ -121,8 +120,7 @@ Install passenger with:
 ### An error "Could not find a default provider for rvm\_system\_ruby" is displayed when running Puppet with --noop
 
 This means that puppet cannot find the `/usr/local/rvm/bin/rvm` command
-(probably because RVM isn't installed yet).  Currently, Puppet does not support
-making a provider suitable using another resource (late-binding).  The
+(probably because RVM isn't installed yet).  The
 puppet-rvm module uses run stages to install RVM before the rest of the
 configuration runs.  When running in _noop_ mode, RVM is not actually installed
 causing rvm\_system\_ruby, rvm\_gem and rvm\_gemset resources to generate this

--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -5,15 +5,23 @@ require 'uri'
 Puppet::Type.type(:rvm_gem).provide(:gem) do
   desc "Ruby Gem support using RVM."
 
-  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  #commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  commands :workaround => "true"
 
+  def get_rvm
+    "/usr/local/rvm/bin/rvm"
+  end
+
+  def rvmcmd(*args)
+    execute( [get_rvm] + args )
+  end
 
   def ruby_version
     resource[:ruby_version]
   end
 
   def gembinary
-    [command(:rvmcmd), ruby_version, "do", "gem"]
+    [get_rvm, ruby_version, "do", "gem"]
   end
 
 

--- a/lib/puppet/provider/rvm_gemset/gemset.rb
+++ b/lib/puppet/provider/rvm_gemset/gemset.rb
@@ -2,7 +2,16 @@
 Puppet::Type.type(:rvm_gemset).provide(:gemset) do
   desc "RVM gemset support."
 
-  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  #commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  commands :workaround => "true"
+
+  def rvmcmd(*args)
+    execute( [get_rvm] + args )
+  end
+
+  def get_rvm
+    "/usr/local/rvm/bin/rvm"
+  end
 
   def ruby_version
     resource[:ruby_version]
@@ -13,11 +22,11 @@ Puppet::Type.type(:rvm_gemset).provide(:gemset) do
   end
 
   def gemsetcommand
-    [command(:rvmcmd), ruby_version, "exec", "rvm", "gemset"]
+    [get_rvm, ruby_version, "exec", "rvm", "gemset"]
   end
 
   def gemsetcommand_force
-    [command(:rvmcmd), ruby_version, "exec", "rvm", "--force", "gemset"]
+    [get_rvm, ruby_version, "exec", "rvm", "--force", "gemset"]
   end
 
   def gemset_list

--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -1,7 +1,13 @@
 Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   desc "Ruby RVM support."
 
-  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  #commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+  commands :workaround => "true"
+
+  def rvmcmd(*args)
+    execute( ["/usr/local/rvm/bin/rvm"] + args )
+  end
+
 
   def create
     rvmcmd "install", resource[:name]


### PR DESCRIPTION
This pull request works around the late binding issue for Providers by faking out Puppet.

With these modifications I was able to take a virgin virtual machine that has never seen RVM and install RVM, a Ruby, and a gemset for that Ruby.

It works by faking out Puppet - saying that it will run a command (the true command), but then turns around and runs RVM at runtime. Sneaky, and probably something that would get me kicked out of the Puppet Users Guild Of Best Practicing Artisans... but it works! :)

Let me know if you have any questions or if there's anything I can do to make this patch better!
_Ryan Wilcox
