### PR TITLE
explicitly scope the $::operatingsystem variable

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -1,5 +1,5 @@
 class rvm::dependencies {
-  case $operatingsystem {
+  case $::operatingsystem {
     Ubuntu,Debian: { require rvm::dependencies::ubuntu }
     CentOS,RedHat: { require rvm::dependencies::centos }
   }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -1,6 +1,6 @@
 class rvm::dependencies::centos {
 
-  case $operatingsystemrelease {
+  case $::operatingsystemrelease {
     /^6\..*/: {
       if ! defined(Package['libcurl-devel']) { package { 'libcurl-devel':      ensure => installed } }
     }

--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -9,7 +9,7 @@ class rvm::passenger::apache(
   $spawnmethod = 'smart-lv2'
 ) {
 
-  case $operatingsystem {
+  case $::operatingsystem {
     Ubuntu: { include rvm::passenger::apache::ubuntu::pre }
     CentOS,RedHat: { include rvm::passenger::apache::centos::pre }
   }
@@ -26,7 +26,7 @@ class rvm::passenger::apache(
   $gempath = "${rvm_prefix}rvm/gems/${ruby_version}/gems"
   $binpath = "${rvm_prefix}rvm/bin/"
 
-  case $operatingsystem {
+  case $::operatingsystem {
     Ubuntu: {
       class { 'rvm::passenger::apache::ubuntu::post':
         ruby_version       => $ruby_version,

--- a/manifests/system_user.pp
+++ b/manifests/system_user.pp
@@ -1,7 +1,7 @@
 define rvm::system_user () {
 
   $username = $title
-  $group = $operatingsystem ? {
+  $group = $::operatingsystem ? {
     default => 'rvm',
   }
 


### PR DESCRIPTION
this silences the following warning being printed on puppet 2.7.11
(and possibly other versions):

"warning: Dynamic lookup of $operatingsystem at
/etc/puppet/modules/rvm/manifests/system_user.pp:4 is deprecated.
Support will be removed in Puppet 2.8.  Use a fully-qualified variable
name (e.g., $classname::variable) or parameterized classes."

let me know if there are any issues with this that i can fix. it's a small change so hopefully there won't be problems.
