### PR TITLE
Added dependency support for Oracle Linux (tested on 5.7)

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -2,5 +2,6 @@ class rvm::dependencies {
   case $operatingsystem {
     Ubuntu,Debian: { require rvm::dependencies::ubuntu }
     CentOS,RedHat: { require rvm::dependencies::centos }
+    OracleLinux,RedHat: { require rvm::dependencies::oraclelinux }
   }
 }

--- a/manifests/dependencies/oraclelinux.pp
+++ b/manifests/dependencies/oraclelinux.pp
@@ -1,0 +1,27 @@
+class rvm::dependencies::oraclelinux {
+
+  if ! defined(Package['which'])           { package { 'which':           ensure => installed } }
+  if ! defined(Package['gcc'])             { package { 'gcc':             ensure => installed } }
+  if ! defined(Package['gcc-c++'])         { package { 'gcc-c++':         ensure => installed } }
+  if ! defined(Package['make'])            { package { 'make':            ensure => installed } }
+  if ! defined(Package['gettext-devel'])   { package { 'gettext-devel':   ensure => installed } }
+  if ! defined(Package['expat-devel'])     { package { 'expat-devel':     ensure => installed } }
+  if ! defined(Package['curl-devel'])      { package { 'curl-devel':      ensure => installed } }
+  if ! defined(Package['zlib-devel'])      { package { 'zlib-devel':      ensure => installed } }
+  if ! defined(Package['openssl-devel'])   { package { 'openssl-devel':   ensure => installed } }
+  if ! defined(Package['perl'])            { package { 'perl':            ensure => installed } }
+  if ! defined(Package['cpio'])            { package { 'cpio':            ensure => installed } }
+  if ! defined(Package['expat-devel'])     { package { 'expat-devel':     ensure => installed } }
+  if ! defined(Package['gettext-devel'])   { package { 'gettext-devel':   ensure => installed } }
+  if ! defined(Package['wget'])            { package { 'wget':            ensure => installed } }
+  if ! defined(Package['bzip2'])           { package { 'bzip2':           ensure => installed } }
+  if ! defined(Package['sendmail'])        { package { 'sendmail':        ensure => installed } }
+  if ! defined(Package['mailx'])           { package { 'mailx':           ensure => installed } }
+  if ! defined(Package['libxml2'])         { package { 'libxml2':         ensure => installed } }
+  if ! defined(Package['libxml2-devel'])   { package { 'libxml2-devel':   ensure => installed } }
+  if ! defined(Package['libxslt'])         { package { 'libxslt':         ensure => installed } }
+  if ! defined(Package['libxslt-devel'])   { package { 'libxslt-devel':   ensure => installed } }
+  if ! defined(Package['readline-devel'])  { package { 'readline-devel':  ensure => installed } }
+  if ! defined(Package['patch'])           { package { 'patch':           ensure => installed } }
+  if ! defined(Package['git'])             { package { 'git':             ensure => installed } }
+}


### PR DESCRIPTION
Dependencies for Oracle Linux 5.7 are identical to CentOS (in the cases I tested) but the $operatingsystem values are different. We will be testing OEL 6.2 soon as well so I can add changes as necessary to support that platform - we've found OEL 6.2 tends to differ more from CentOS 6.2 than the 5 series does. 
