### PR TITLE
add a workaround for duplicate class definitions

### DIFF
--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -28,31 +28,35 @@ class rvm::passenger::apache(
 
   case $operatingsystem {
     Ubuntu: {
-      class { 'rvm::passenger::apache::ubuntu::post':
-        ruby_version       => $ruby_version,
-        version            => $version,
-        rvm_prefix         => $rvm_prefix,
-        mininstances       => $mininstances,
-        maxpoolsize        => $maxpoolsize,
-        poolidletime       => $poolidletime,
-        maxinstancesperapp => $maxinstancesperapp,
-        spawnmethod        => $spawnmethod,
-        gempath            => $gempath,
-        binpath            => $binpath;
+      if !defined(Class['rvm::passenger::apache::ubuntu::post']) {
+        class { 'rvm::passenger::apache::ubuntu::post':
+          ruby_version       => $ruby_version,
+          version            => $version,
+          rvm_prefix         => $rvm_prefix,
+          mininstances       => $mininstances,
+          maxpoolsize        => $maxpoolsize,
+          poolidletime       => $poolidletime,
+          maxinstancesperapp => $maxinstancesperapp,
+          spawnmethod        => $spawnmethod,
+          gempath            => $gempath,
+          binpath            => $binpath;
+        }
       }
     }
     CentOS,RedHat: {
-      class { 'rvm::passenger::apache::centos::post':
-        ruby_version       => $ruby_version,
-        version            => $version,
-        rvm_prefix         => $rvm_prefix,
-        mininstances       => $mininstances,
-        maxpoolsize        => $maxpoolsize,
-        poolidletime       => $poolidletime,
-        maxinstancesperapp => $maxinstancesperapp,
-        spawnmethod        => $spawnmethod,
-        gempath            => $gempath,
-        binpath            => $binpath;
+      if !defined(Class['rvm::passenger::apache::centos::post']) {
+        class { 'rvm::passenger::apache::centos::post':
+          ruby_version       => $ruby_version,
+          version            => $version,
+          rvm_prefix         => $rvm_prefix,
+          mininstances       => $mininstances,
+          maxpoolsize        => $maxpoolsize,
+          poolidletime       => $poolidletime,
+          maxinstancesperapp => $maxinstancesperapp,
+          spawnmethod        => $spawnmethod,
+          gempath            => $gempath,
+          binpath            => $binpath;
+        }
       }
     }
   }


### PR DESCRIPTION
As the automatic dependency resolution did not work properly, I needed to include the pre- and post-dependencies into my manifests.

The resulting "duplicate definition" error needs a safeguard, which I added.

I don't know how to solve the underlying issue of the broken dependency resolution.

I use puppet 2.7.1 and cucumber-puppet 0.3.8. The failure occured in my tests...

see PullRequest/Issue #42 for previous discussion. Maybe this is not even needed in the long run.
