### PR TITLE
Unable to find 'curl-devel' package on Oracle Linux using YUM package manager

### DIFF
--- a/manifests/dependencies/oraclelinux.pp
+++ b/manifests/dependencies/oraclelinux.pp
@@ -6,7 +6,7 @@ class rvm::dependencies::oraclelinux {
   if ! defined(Package['make'])            { package { 'make':            ensure => installed } }
   if ! defined(Package['gettext-devel'])   { package { 'gettext-devel':   ensure => installed } }
   if ! defined(Package['expat-devel'])     { package { 'expat-devel':     ensure => installed } }
-  if ! defined(Package['curl-devel'])      { package { 'curl-devel':      ensure => installed } }
+  if ! defined(Package['libcurl-devel'])   { package { 'libcurl-devel':   ensure => installed } }
   if ! defined(Package['zlib-devel'])      { package { 'zlib-devel':      ensure => installed } }
   if ! defined(Package['openssl-devel'])   { package { 'openssl-devel':   ensure => installed } }
   if ! defined(Package['perl'])            { package { 'perl':            ensure => installed } }


### PR DESCRIPTION
On Oracle Linux, YUM was unable to find a package named 'curl-devel', but 'libcurl-devel' installed and worked just fine, so I think this should be changed.
