### PR TITLE
Fixes bug where every puppet run reinstalls already installed gems

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -5,6 +5,7 @@ require 'uri'
 Puppet::Type.type(:rvm_gem).provide(:gem) do
   desc "Ruby Gem support using RVM."
 
+  has_feature :versionable
   commands :rvmcmd => "/usr/local/rvm/bin/rvm"
 
 
@@ -56,7 +57,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
     when /gem: not found/; return nil
     when /^(\S+)\s+\((((((\d+[.]?))+)(,\s)*)+)\)/
       name = $1
-      version = $2.split(/,\s*/)[0]
+      version = $2.split(/,\s*/)
       return {
         :name => name,
         :ensure => version
@@ -107,7 +108,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
     # This always gets the latest version available.
     hash = gemlist(:justme => resource[:name])
 
-    hash[:ensure]
+    hash[:ensure][0]
   end
 
   def query

--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
     case desc
     when /^\*\*\*/, /^\s*$/, /^\s+/; return nil
     when /gem: not found/; return nil
-    when /^(\S+)\s+\(([^ ]+).*\)/
+    when /^(\S+)\s+\((((((\d+[.]?))+)(,\s)*)+)\)/
       name = $1
       version = $2.split(/,\s*/)[0]
       return {

--- a/lib/puppet/type/rvm_gem.rb
+++ b/lib/puppet/type/rvm_gem.rb
@@ -86,6 +86,12 @@ Puppet::Type.newtype(:rvm_gem) do
           end
 
           case is
+          when is.is_a?(Array)
+            if is.include?(@latest)
+              return true
+            else
+              return false
+            end
           when @latest
             return true
           else
@@ -93,7 +99,7 @@ Puppet::Type.newtype(:rvm_gem) do
           end
         when :absent
           return true if is == :absent
-        when is
+        when *Array(is)
           return true
         end
       }


### PR DESCRIPTION
Every gem that was set to a version other than latest was reinstalling on every puppet run. I found that the official gem module from puppet suffered from a similar problem, and was fixed a while ago.
http://projects.puppetlabs.com/issues/13397
https://github.com/puppetlabs/puppet/pull/614
I used a similar strategy to fix the problem with rvm_gem

It might actually rely on the referenced puppet fix, but I've only tested with puppet 2.7.19 so I'm not sure.
