### PR TITLE
updates to rvm_gem to allow passing build options

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -99,6 +99,12 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
       command << "--no-rdoc" << "--no-ri" <<  resource[:name]
     end
 
+    # makefile opts,
+    # must be last
+    if resource[:withopts]
+      command << "--" << resource[:withopts]
+    end
+
     output = execute(command)
     # Apparently some stupid gem versions don't exit non-0 on failure
     self.fail "Could not install: #{output.chomp}" if output.include?("ERROR")

--- a/lib/puppet/type/rvm_gem.rb
+++ b/lib/puppet/type/rvm_gem.rb
@@ -125,6 +125,10 @@ Puppet::Type.newtype(:rvm_gem) do
     isnamevar
   end
 
+  newparam(:withopts) do
+    desc "Install the gem with these makefile opts."
+  end
+
   newparam(:source) do
     desc "If a URL is passed via, then that URL is used as the
     remote gem repository; if a source is present but is not a valid URL, it will be


### PR DESCRIPTION
I've been using this locally, not sure if it's of any interest, but if so, feel free to include it. We have a lot of cases where we compile and install software in non-system locations, so being able to build gems referencing those installations is necessary.

Basically, just a few changes to rvm_gem to allow passing build options, e.g. 

  rvm_gem {'igraph':
    ruby_version => $rvm_common::ruby_appversion,
    require      => [Rvm_system_ruby[$rvm_common::ruby_appversion], Class['igraph']],
    ensure       => '0.9.7',
    withopts     => '--with-igraph-include=/opt/igraph/include/igraph --with-igraph-lib=/opt/igraph/lib',
    tag              => 'rvm',
  }
