### PR TITLE
add rvm_alias puppet provider and type

### DIFF
--- a/lib/puppet/provider/rvm_alias/alias.rb
+++ b/lib/puppet/provider/rvm_alias/alias.rb
@@ -1,0 +1,44 @@
+# RVM gemset support
+Puppet::Type.type(:rvm_alias).provide(:alias) do
+  desc "RVM alias support."
+
+  commands :rvmcmd => "/usr/local/rvm/bin/rvm"
+
+  def ruby_version
+    resource[:ruby_version]
+  end
+
+  def alias_name
+    resource[:name]
+  end
+
+  def aliascmd
+    [command(:rvmcmd), "alias"]
+  end
+
+  def alias_list
+    command = aliascmd + ['list']
+
+    list = []
+    begin
+      list = execute(command)
+    rescue Puppet::ExecutionFailure => detail
+    end
+
+    list
+  end
+
+  def create
+    command = aliascmd + ['create', alias_name, ruby_version]
+    execute(command)
+  end
+
+  def destroy
+    command = aliascmd + ['delete', alias_name]
+    execute(command)
+  end
+
+  def exists?
+    alias_list.include? alias_name
+  end
+end

--- a/lib/puppet/provider/rvm_alias/alias.rb
+++ b/lib/puppet/provider/rvm_alias/alias.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:rvm_alias).provide(:alias) do
     rescue Puppet::ExecutionFailure => detail
     end
 
-    list
+    list.to_s
   end
 
   def create
@@ -39,6 +39,6 @@ Puppet::Type.type(:rvm_alias).provide(:alias) do
   end
 
   def exists?
-    alias_list.include? alias_name
+    alias_list.match("#{alias_name} => #{ruby_version}")
   end
 end

--- a/lib/puppet/provider/rvm_alias/alias.rb
+++ b/lib/puppet/provider/rvm_alias/alias.rb
@@ -4,8 +4,8 @@ Puppet::Type.type(:rvm_alias).provide(:alias) do
 
   commands :rvmcmd => "/usr/local/rvm/bin/rvm"
 
-  def ruby_version
-    resource[:ruby_version]
+  def target_ruby
+    resource[:target_ruby]
   end
 
   def alias_name
@@ -29,7 +29,7 @@ Puppet::Type.type(:rvm_alias).provide(:alias) do
   end
 
   def create
-    command = aliascmd + ['create', alias_name, ruby_version]
+    command = aliascmd + ['create', alias_name, target_ruby]
     execute(command)
   end
 
@@ -39,6 +39,6 @@ Puppet::Type.type(:rvm_alias).provide(:alias) do
   end
 
   def exists?
-    alias_list.match("#{alias_name} => #{ruby_version}")
+    alias_list.match("#{alias_name} => #{target_ruby}")
   end
 end

--- a/lib/puppet/type/rvm_alias.rb
+++ b/lib/puppet/type/rvm_alias.rb
@@ -1,0 +1,21 @@
+Puppet::Type.newtype(:rvm_alias) do
+  @doc = "Manage RVM Aliases."
+
+  #def self.title_patterns
+  #  [ [ /^(?:(.*)@)?(.*)$/, [ [ :ruby_version, lambda{|x| x} ], [ :name, lambda{|x| x} ] ] ] ]
+  #end
+
+  ensurable
+
+  newparam(:name) do
+    desc "The name of the alias to be managed."
+    isnamevar
+  end
+
+  newparam(:ruby_version) do
+    desc "The ruby version that is the target of our alias.  This should be the fully qualified RVM string.
+    For example: 'ruby-1.9.2-p290'
+    For a full list of known strings: `rvm list known_strings`."
+  end
+
+end

--- a/lib/puppet/type/rvm_alias.rb
+++ b/lib/puppet/type/rvm_alias.rb
@@ -1,10 +1,6 @@
 Puppet::Type.newtype(:rvm_alias) do
   @doc = "Manage RVM Aliases."
 
-  #def self.title_patterns
-  #  [ [ /^(?:(.*)@)?(.*)$/, [ [ :ruby_version, lambda{|x| x} ], [ :name, lambda{|x| x} ] ] ] ]
-  #end
-
   ensurable
 
   newparam(:name) do
@@ -12,10 +8,9 @@ Puppet::Type.newtype(:rvm_alias) do
     isnamevar
   end
 
-  newparam(:ruby_version) do
-    desc "The ruby version that is the target of our alias.  This should be the fully qualified RVM string.
-    For example: 'ruby-1.9.2-p290'
-    For a full list of known strings: `rvm list known_strings`."
+  newparam(:target_ruby) do
+    desc "The ruby version that is the target of our alias.
+    For example: 'ruby-1.9.2-p290'"
   end
 
 end


### PR DESCRIPTION
Explicit rvm_alias provider support:

  rvm_alias { 'puppet-default' :
    ensure       => 'present',
    ruby_version => "${ruby_puppetversion}@puppet",
    tag          => 'rvm',
  }

Questions, let me know, and definitely give it a once-over. 

Cheers,
-Grant
