### PR TITLE
passenger ruby version requirement

### DIFF
--- a/manifests/passenger/gem.pp
+++ b/manifests/passenger/gem.pp
@@ -2,6 +2,7 @@ class rvm::passenger::gem($ruby_version, $version) {
   rvm_gem {
     "passenger":
       ensure       => $version,
+      require => Rvm_system_ruby["${ruby_version}"],
       ruby_version => $ruby_version;
   }
 }


### PR DESCRIPTION
provide a way for puppet to ensure that the version of ruby required for passenger is a pre-requisite
