### PR TITLE
Ability to pass compile options, pkg install to Rvm_system_ruby

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,6 +66,20 @@ You can tell RVM to install one or more Ruby versions with:
 
 You should use the full version number.  While the shorthand version may work (e.g. '1.9.2'), the provider will be unable to detect if the correct version is installed.
 
+## Installing Ruby with options / or packages (OR: *building Rubies with a modern OpenSSL*)
+
+RVM has several packages that provide required libraries for OS configurations that might not have up to date components. A good example of this is OpenSSL - Ruby 2.0 (for example) depends on OpenSSL 1.x, but most OSes ship with OpenSSL 0.9.x.
+
+There are two new parameters you can use:
+
+    rvm_system_ruby {
+     'ruby-1.8.7':
+       ensure => 'present',
+       pkg => "openssl",
+       install_opts => "--with-openssl-dir=$rvm_path/usr"
+    }
+
+This will tell RVM to install the openSSL package, then compile RVM with options that point the build process to the new OpenSSL path.
 
 ## Creating Gemsets
 

--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -4,7 +4,13 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   commands :rvmcmd => "/usr/local/rvm/bin/rvm"
 
   def create
-    rvmcmd "install", resource[:name]
+    if resource[:pkg]
+      puts "rvmcmd pkg install #{resource[:pkg]}"
+      rvmcmd "pkg install", resource[:pkg]
+    end
+
+    options = resource[:withopts]
+    rvmcmd "install", resource[:name], options
     set_default if resource.value(:default_use)
   end
 

--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
       rvmcmd "pkg", "install", resource[:pkg]
     end
 
-    options = resource[:withopts]
+    options = resource[:install_opts]
     rvmcmd "install", resource[:name], options
     set_default if resource.value(:default_use)
   end

--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -5,8 +5,8 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
 
   def create
     if resource[:pkg]
-      puts "rvmcmd pkg install #{resource[:pkg]}"
-      rvmcmd "pkg install", resource[:pkg]
+      #puts "rvm pkg install #{resource[:pkg]}"
+      rvmcmd "pkg", "install", resource[:pkg]
     end
 
     options = resource[:withopts]

--- a/lib/puppet/type/rvm_system_ruby.rb
+++ b/lib/puppet/type/rvm_system_ruby.rb
@@ -13,12 +13,12 @@ Puppet::Type.newtype(:rvm_system_ruby) do
     defaultto false
   end
 
-  newproperty(:withopts) do
+  newparam(:install_opts) do
     desc "Flags to compile RVM with ie: --with-openssl-dir=..."
     defaultto ""
   end
 
-  newproperty(:pkg) do
+  newparam(:pkg) do
     desc "install package for this system ruby"
   end
 end

--- a/lib/puppet/type/rvm_system_ruby.rb
+++ b/lib/puppet/type/rvm_system_ruby.rb
@@ -12,4 +12,13 @@ Puppet::Type.newtype(:rvm_system_ruby) do
     desc "Should this Ruby be the system default for new terminals?"
     defaultto false
   end
+
+  newproperty(:withopts) do
+    desc "Flags to compile RVM with ie: --with-openssl-dir=..."
+    defaultto ""
+  end
+
+  newproperty(:pkg) do
+    desc "install package for this system ruby"
+  end
 end


### PR DESCRIPTION
I've added support for installing rvm packages via the `Rvm_system_ruby` type, and also added the ability to pass compile time options.

I implemented this because I found that the OpenSSL version on my OS was too old for RubyGems 2.0 / Ruby 2.0. I followed the instructions in a gist (https://gist.github.com/jfirebaugh/4007524) to use RVM's openssl package and that worked! But I wanted to automate that, so I made some modifcations.

Anyway, hope this helps! Let me know if I can change anything, etc etc.
