### PR TITLE
ruby_version should allow fully qualified strings including gemset

### DIFF
--- a/manifests/passenger/gem.pp
+++ b/manifests/passenger/gem.pp
@@ -1,8 +1,9 @@
 class rvm::passenger::gem($ruby_version, $version) {
+  $ruby_version_only = regsubst($ruby_version,'([^@]+)(@(.+))?','\1')
   rvm_gem {
     "passenger":
       ensure       => $version,
-      require => Rvm_system_ruby["${ruby_version}"],
+      require      => Rvm_system_ruby["${ruby_version_only}"],
       ruby_version => $ruby_version;
   }
 }


### PR DESCRIPTION
Pull request 60 / 790bdab solved a longstanding problem we had with passenger dependency order, but it broke the ability to use a fully qualified RVM ruby_version string like "ruby-1.9.3-p392@mygemset" with rvm::passenger::apache.

lib/puppet/type/rvm_gem.rb describes the ruby_version string as:

```
The ruby version to use.  This should be the fully qualified RVM string
(including gemset if applicable).  For example: 'ruby-1.9.2-p136@mygemset'
```

This pull request restores the ability to pass a fully qualified ruby_version string to the rvm::passenger::apache parametrized class.

Cheers and thanks to @blt04 for the module and @angusscown for the dependency fix!
