### PR TITLE
Have rvm_system_ruby accept build flags

### DIFF
--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -4,7 +4,8 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   commands :rvmcmd => "/usr/local/rvm/bin/rvm"
 
   def create
-    rvmcmd "install", resource[:name]
+    options = Array(resource[:build_opts])
+    rvmcmd "install", resource[:name], *options
     set_default if resource.value(:default_use)
   end
 

--- a/lib/puppet/type/rvm_system_ruby.rb
+++ b/lib/puppet/type/rvm_system_ruby.rb
@@ -8,8 +8,14 @@ Puppet::Type.newtype(:rvm_system_ruby) do
     isnamevar
   end
 
+  newparam(:build_opts) do
+    desc "Build flags for RVM (e.g.: ['--movable', '--with-libyaml-dir=...', ...])"
+    defaultto ""
+  end
+
   newproperty(:default_use) do
     desc "Should this Ruby be the system default for new terminals?"
     defaultto false
   end
+
 end


### PR DESCRIPTION
I realize this pull request partially duplicates #68, but I thought it was worth considering the different pieces of functionality separately. Whether or not you want to support `rvm pkg` and `autolibs`, it kind of seems like a no-brainer to allow build flags.
