### PR TITLE
Add property to allow passing autolibs mode for Issue #71

### DIFF
--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -4,6 +4,7 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   commands :rvmcmd => "/usr/local/rvm/bin/rvm"
 
   def create
+    set_autolib_mode if resource.value(:autolib_mode)
     rvmcmd "install", resource[:name]
     set_default if resource.value(:default_use)
   end
@@ -39,5 +40,13 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
 
   def set_default
     rvmcmd "alias", "create", "default", resource[:name]
+  end
+ 
+  def set_autolib_mode
+    begin 
+      rvmcmd "autolibs", resource[:autolib_mode]
+    rescue Puppet::ExecutionFailure => detail
+      raise Puppet::Error, "Could not set autolib mode: #{detail}"
+    end
   end
 end

--- a/lib/puppet/type/rvm_system_ruby.rb
+++ b/lib/puppet/type/rvm_system_ruby.rb
@@ -12,4 +12,9 @@ Puppet::Type.newtype(:rvm_system_ruby) do
     desc "Should this Ruby be the system default for new terminals?"
     defaultto false
   end
+
+  newproperty(:autolib_mode) do
+    desc "Set RVM autolib mode"
+  end
+
 end


### PR DESCRIPTION
This will allow a user to specify an autolibs mode before a system ruby install.  

Example:

```
rvm_system_ruby {
  'ruby-1.9.2-p290':
    ensure => 'present',
    default_use => true,
    autolib_mode => 'enabled';
}
```
