### PR TITLE
Centos 6 Dependencies Updated

### DIFF
--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -3,15 +3,20 @@ class rvm::dependencies::centos {
   case $::operatingsystemrelease {
     /^6\..*/: {
       if ! defined(Package['libcurl-devel']) { package { 'libcurl-devel':      ensure => present } }
+      if ! defined(Package['libyaml-devel']) { package { 'libyaml-devel':      ensure => present } }
+      if ! defined(Package['libffi-devel'])  { package { 'libffi-devel':       ensure => present } }
+      if ! defined(Package['libtool'])       { package { 'libtool':            ensure => present } }
+      if ! defined(Package['bison'])         { package { 'bison':              ensure => present } }
     }
     /^5\..*/: {
-      if ! defined(Package['bison'])        { package { 'bison':         ensure => present } }
+      
       if ! defined(Package['autoconf'])     { package { 'autoconf':      ensure => present } }
     }
     default: {
       if ! defined(Package['curl-devel'])    { package { 'curl-devel':      ensure => present } }
     }
   }
+  if ! defined(Package['bison'])           { package { 'bison':           ensure => present } }
   if ! defined(Package['which'])           { package { 'which':           ensure => present } }
   if ! defined(Package['gcc'])             { package { 'gcc':             ensure => present } }
   if ! defined(Package['gcc-c++'])         { package { 'gcc-c++':         ensure => present } }


### PR DESCRIPTION
We use Centos 6.3 at my job and I had to made the following tweaks to get ruby 2.0.0 to install cleanly.

Tested using vagrant with a Centos 6.3 base image.
