### PR TITLE
Simpler regex for installed gem version detection.

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -55,7 +55,8 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
     case desc
     when /^\*\*\*/, /^\s*$/, /^\s+/; return nil
     when /gem: not found/; return nil
-    when /^(\S+)\s+\((((((\d+[.]?))+)(,\s)*)+)\)/
+    # when /^(\S+)\s+\((((((\d+[.]?))+)(,\s)*)+)\)/
+    when /^(\S+)\s+\((\d+.*)\)/
       name = $1
       version = $2.split(/,\s*/)
       return {


### PR DESCRIPTION
The current regex used for checking if a gem is already installed fails for some gems, e.g. rails 4.0.0.rc1 - due to the 'rc1' suffix the version number is not matched.

I don't really see the point of using a regex as complex as was used for this. If all you want to do is split the gem name (sequence of word chars followed by whitespace) and gem version (everything inside brackets following the gem name) I figure a much simpler and thus more robust regex would do. 

Maybe I'm missing something, otherwise I'd propose the simplified pattern in my commit.
