### PR TITLE
Ensure that puppet fails if system-rvm installation fails

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,9 +1,9 @@
 class rvm::system($version='latest') {
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',
-    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer ; \
-                chmod +x /tmp/rvm-installer ; \
-                rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${version} ; \
+    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
+                chmod +x /tmp/rvm-installer && \
+                rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${actual_version} && \
                 rm /tmp/rvm-installer'",
     creates => '/usr/local/rvm/bin/rvm',
     require => [


### PR DESCRIPTION
If any of the commands in the shell script to install rvm fails, puppet doesn't fail. Fix that
