### PR TITLE
change path to mod passenger.so to support puppet >= 3.9.0.beta on CentOS

### DIFF
--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -1,4 +1,8 @@
+<% if version >= '3.9.0' %>
+LoadModule passenger_module <%= gempath %>/passenger-<%= version %>/libout/apache2/mod_passenger.so
+<% else %>
 LoadModule passenger_module <%= gempath %>/passenger-<%= version %>/ext/apache2/mod_passenger.so
+<% end %>
 
 <IfModule passenger_module>
   PassengerRoot <%= gempath %>/passenger-<%= version %>


### PR DESCRIPTION
path to mod_passenger.so module was changed from ext/apache2/mod_passenger.so
to libout/apache2/mod_passenger.so in version 3.9.0.beta of passenger
(https://github.com/FooBarWidget/passenger/commit/1d7ea010adea0a3f51a)
