### PR TITLE
Corrected variable scoping with mod_passenger and puppet 3.x

### DIFF
--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -1,13 +1,13 @@
-LoadModule passenger_module <%= gempath %>/passenger-<%= version %>/ext/apache2/mod_passenger.so
+LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/ext/apache2/mod_passenger.so
 
 <IfModule passenger_module>
-  PassengerRoot <%= gempath %>/passenger-<%= version %>
-  PassengerRuby <%= rvm_prefix %>rvm/wrappers/<%= ruby_version %>/ruby
-  PassengerMaxPoolSize <%= maxpoolsize %>
-  PassengerPoolIdleTime <%= poolidletime %>
-  PassengerMaxInstancesPerApp <%= maxinstancesperapp %>
+  PassengerRoot <%= @gempath %>/passenger-<%= @version %>
+  PassengerRuby <%= @rvm_prefix %>rvm/wrappers/<%= @ruby_version %>/ruby
+  PassengerMaxPoolSize <%= @maxpoolsize %>
+  PassengerPoolIdleTime <%= @poolidletime %>
+  PassengerMaxInstancesPerApp <%= @maxinstancesperapp %>
 <% if version >= '3.0.0' %>
-  PassengerMinInstances <%= mininstances %>
-  PassengerSpawnMethod <%= spawnmethod %>
+  PassengerMinInstances <%= @mininstances %>
+  PassengerSpawnMethod <%= @spawnmethod %>
 <% end %>
 </IfModule>

--- a/templates/passenger-apache.conf.erb
+++ b/templates/passenger-apache.conf.erb
@@ -1,9 +1,9 @@
 <IfModule passenger_module>
-  PassengerRoot <%= gempath %>/passenger-<%= version %>
-  PassengerRuby <%= rvm_prefix %>rvm/wrappers/<%= ruby_version %>/ruby
-  PassengerMaxPoolSize <%= maxpoolsize %>
-  PassengerPoolIdleTime <%= poolidletime %>
-  PassengerMinInstances <%= mininstances %>
-  PassengerMaxInstancesPerApp <%= maxinstancesperapp %>
-  PassengerSpawnMethod <%= spawnmethod %>
+  PassengerRoot <%= @gempath %>/passenger-<%= @version %>
+  PassengerRuby <%= @rvm_prefix %>rvm/wrappers/<%= @ruby_version %>/ruby
+  PassengerMaxPoolSize <%= @maxpoolsize %>
+  PassengerPoolIdleTime <%= @poolidletime %>
+  PassengerMinInstances <%= @mininstances %>
+  PassengerMaxInstancesPerApp <%= @maxinstancesperapp %>
+  PassengerSpawnMethod <%= @spawnmethod %>
 </IfModule>


### PR DESCRIPTION
Encountered variable variable referencing problems with puppet 3.1.1
Corrected variable scoping by prepending an @ to focus on current
scope (see http://docs.puppetlabs.com/guides/templating.html )
