### PR TITLE
Fix missing "version" variable scoping with mod_passenger and puppet 3.x

### DIFF
--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -2,6 +2,8 @@ class rvm::passenger::apache(
   $ruby_version,
   $version,
   $rvm_prefix = '/usr/local/',
+  $rails_env = undef,
+  $rack_env = undef,
   $mininstances = '1',
   $maxpoolsize = '6',
   $poolidletime = '300',

--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -1,4 +1,6 @@
-<% if @version >= '3.9.0' %>
+<% if @version >= '4.0.7' %>
+LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/buildout/apache2/mod_passenger.so 
+<% elsif @version >= '3.9.0' %>
 LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/libout/apache2/mod_passenger.so
 <% else %>
 LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/ext/apache2/mod_passenger.so

--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -1,4 +1,4 @@
-<% if version >= '3.9.0' %>
+<% if @version >= '3.9.0' %>
 LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/libout/apache2/mod_passenger.so
 <% else %>
 LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/ext/apache2/mod_passenger.so
@@ -10,7 +10,7 @@ LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/ext/apache
   PassengerMaxPoolSize <%= @maxpoolsize %>
   PassengerPoolIdleTime <%= @poolidletime %>
   PassengerMaxInstancesPerApp <%= @maxinstancesperapp %>
-<% if version >= '3.0.0' %>
+<% if @version >= '3.0.0' %>
   PassengerMinInstances <%= @mininstances %>
   PassengerSpawnMethod <%= @spawnmethod %>
 <% end %>

--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -16,4 +16,12 @@ LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/ext/apache
   PassengerMinInstances <%= @mininstances %>
   PassengerSpawnMethod <%= @spawnmethod %>
 <% end %>
+
+<% if @rails_env -%>
+  RailsEnv <%= @rails_env %>
+<% end -%>
+<% if @rails_env -%>
+  RackEnv <%= @rack_env %>
+<% end -%>
+
 </IfModule>


### PR DESCRIPTION
[Pull request 84](https://github.com/blt04/puppet-rvm/pull/84) missed the **version** variable, which is deprecated as well and needs to be replaced with **@version**
