### PR TITLE
New phusion module directory

### DIFF
--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -1,4 +1,7 @@
-<% if version >= '3.9.0' %>
+<% if version >= '4.0.7' %>
+LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/buildout/apache2/mod
+_passenger.so
+<% elsif version >= '3.9.0' %>
 LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/libout/apache2/mod_passenger.so
 <% else %>
 LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/ext/apache2/mod_passenger.so

--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -1,6 +1,5 @@
 <% if version >= '4.0.7' %>
-LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/buildout/apache2/mod
-_passenger.so
+LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/buildout/apache2/mod_passenger.so
 <% elsif version >= '3.9.0' %>
 LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/libout/apache2/mod_passenger.so
 <% else %>


### PR DESCRIPTION
As of Phusion Passenger version 4.0.7 the compiled mod_passenger.so module is located in a NEW directory.  This small patch adds a different load path based on the new location while retaining the prior locations for previous versions.
