### PR TITLE
Silence output of fact if nothing is done about it

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -20,9 +20,9 @@ class rvm::system($version=undef) {
 
   # the fact won't work until rvm is installed before puppet starts
   if "${::rvm_version}" != "" {
-    notify { 'rvm_version': message => "RVM version ${::rvm_version}" }
-
     if ($version != undef) and ($version != present) and ($version != $::rvm_version) {
+      notify { 'rvm_version': message => "RVM version ${::rvm_version}" }
+
       # Update the rvm installation to the version specified
       notify { 'rvm-get_version':
         message => "RVM updating to version ${version}",


### PR DESCRIPTION
Foreman - if used as a dashboard - interprets the notice as an action, thereby marking every puppet run as "something has been changed on the system".

I moved the notify inside the conditional so it gets executed if the user wants a specific version. The fact can still be queried through facter and gets syncronised into foreman.
