### PR TITLE
Allow to pass environment variables to the gem type

### DIFF
--- a/lib/puppet/type/rvm_gem.rb
+++ b/lib/puppet/type/rvm_gem.rb
@@ -145,4 +145,20 @@ Puppet::Type.newtype(:rvm_gem) do
     isnamevar
   end
 
+  newparam(:environment) do
+    desc "Any additional environment variables you want to set for a
+      command.  Note that if you use this to set PATH, it will override
+      the `path` attribute.  Multiple environment variables should be
+      specified as an array."
+
+    validate do |values|
+      values = [values] unless values.is_a? Array
+      values.each do |value|
+        unless value =~ /\w+=/
+          raise ArgumentError, "Invalid environment setting '#{value}'"
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This is very useful when install gems like buildr that requires access to the JAVA_HOME environment variable:

```
rvm_gem {
  "${ruby193}@buildr/buildr":
    ensure => '1.4.7',
    environment => "JAVA_HOME=/usr/lib/jvm/java-6-openjdk/",
    require => [Rvm_gemset["${ruby193}@buildr"], Package["openjdk-6-jdk"]];
}
```
