### PR TITLE
mod_passenger.so is now built in different dir: buildout/apache2/

### DIFF
--- a/manifests/passenger/apache/ubuntu/post.pp
+++ b/manifests/passenger/apache/ubuntu/post.pp
@@ -14,7 +14,7 @@ class rvm::passenger::apache::ubuntu::post(
   exec {
     'passenger-install-apache2-module':
       command   => "${binpath}rvm ${ruby_version} exec passenger-install-apache2-module -a",
-      creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
+      creates   => "${gempath}/passenger-${version}/buildout/apache2/mod_passenger.so",
       logoutput => 'on_failure',
       require   => [Rvm_gem['passenger'], Package['apache2', 'build-essential', 'apache2-prefork-dev',
                                                   'libapr-dev', 'libaprutil-dev', 'libcurl4-openssl-dev']],
@@ -23,7 +23,7 @@ class rvm::passenger::apache::ubuntu::post(
   file {
     '/etc/apache2/mods-available/passenger.load':
       ensure  => file,
-      content => "LoadModule passenger_module ${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
+      content => "LoadModule passenger_module ${gempath}/passenger-${version}/buildout/apache2/mod_passenger.so",
       require => Exec['passenger-install-apache2-module'];
 
     '/etc/apache2/mods-available/passenger.conf':


### PR DESCRIPTION
Ubuntu 12.04.3 LTS (Precise Pangolin)
rvm 1.22.10
passenger-4.0.16
