### PR TITLE
remove libyaml dependency on centos 6, available only on centos 5

### DIFF
--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -11,6 +11,12 @@ class rvm::dependencies::centos {
       if ! defined(Package['curl-devel'])    { package { 'curl-devel':      ensure => present } }
     }
   }
+  case $::operatingsystemrelease {
+    /^5\..*/: {
+      if ! defined(Package['libyaml-devel'])   { package { 'libyaml-devel':   ensure => present } }
+    }
+  }
+
   if ! defined(Package['which'])           { package { 'which':           ensure => present } }
   if ! defined(Package['gcc'])             { package { 'gcc':             ensure => present } }
   if ! defined(Package['gcc-c++'])         { package { 'gcc-c++':         ensure => present } }
@@ -31,7 +37,6 @@ class rvm::dependencies::centos {
   if ! defined(Package['readline-devel'])  { package { 'readline-devel':  ensure => present } }
   if ! defined(Package['patch'])           { package { 'patch':           ensure => present } }
   if ! defined(Package['git'])             { package { 'git':             ensure => present } }
-  if ! defined(Package['libyaml-devel'])   { package { 'libyaml-devel':   ensure => present } }
   if ! defined(Package['libffi-devel'])    { package { 'libffi-devel':    ensure => present } }
   if ! defined(Package['libtool'])         { package { 'libtool':         ensure => present } }
   if ! defined(Package['bison'])           { package { 'bison':           ensure => present } }

--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -6,14 +6,10 @@ class rvm::dependencies::centos {
     }
     /^5\..*/: {
       if ! defined(Package['autoconf'])     { package { 'autoconf':      ensure => present } }
+      if ! defined(Package['libyaml-devel'])   { package { 'libyaml-devel':   ensure => present } }
     }
     default: {
       if ! defined(Package['curl-devel'])    { package { 'curl-devel':      ensure => present } }
-    }
-  }
-  case $::operatingsystemrelease {
-    /^5\..*/: {
-      if ! defined(Package['libyaml-devel'])   { package { 'libyaml-devel':   ensure => present } }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/blt04/puppet-rvm/issues/96
