### PR TITLE
Allow installation from mirrored repositories

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,23 @@
-class rvm($version=undef, $install_rvm=true) {
+class rvm(
+  $version = undef,
+  $install_rvm = true,
+  $url = 'https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer',
+  $source = 'github.com/wayneeseguin/rvm') {
+
   stage { 'rvm-install': before => Stage['main'] }
 
   if $install_rvm {
-    class {
-      'rvm::dependencies': stage => 'rvm-install';
-      'rvm::system':       stage => 'rvm-install', version => $version;
+
+    class {'rvm::dependencies':
+      stage => 'rvm-install'
     }
+
+    class {'rvm::system':
+      stage => 'rvm-install',
+      version => $version,
+      url => $url,
+      source  => $source;
+    }
+
   }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -1,4 +1,7 @@
-class rvm::system($version=undef) {
+class rvm::system(
+  $version=undef,
+  $url='https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer',
+  $source='github.com/wayneeseguin/rvm') {
 
   $actual_version = $version ? {
     undef     => 'latest',
@@ -8,9 +11,9 @@ class rvm::system($version=undef) {
 
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',
-    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
+    command => "bash -c '/usr/bin/curl -s ${url} -o /tmp/rvm-installer && \
                 chmod +x /tmp/rvm-installer && \
-                rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${actual_version} && \
+                rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --source ${source} --version ${actual_version} && \
                 rm /tmp/rvm-installer'",
     creates => '/usr/local/rvm/bin/rvm',
     require => [
@@ -30,7 +33,7 @@ class rvm::system($version=undef) {
       } ->
       exec { 'system-rvm-get':
         path    => '/usr/local/rvm/bin:/usr/bin:/usr/sbin:/bin',
-        command => "rvm get ${version}",
+        command => "rvm get --source ${source} ${version}",
         before  => Exec['system-rvm'], # so it doesn't run after being installed the first time
       }
     }


### PR DESCRIPTION
RVM's installer now supports the specification of a source repository
for installation from non standard locations (i.e., internally hosted
repositories).
