### PR TITLE
Name check should be exact, not globbed

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
     end
 
     if name = hash[:justme]
-      command << name + "$"
+      command << '^' + name + '$'
     end
 
     list = []


### PR DESCRIPTION
Previous behavior would match anything containing the name, rather than exactly matching the name. This causes problems when you have two gems that match. It will always reinstall the gem if ensure is latest, present, etc. For example, "redis" would match hiredis and redis gems.

This change forces an exact match in the gem list.
