### PR TITLE
Fix mod_passenger.so location wrong for passenger >= '4.0.0'

### DIFF
--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -10,10 +10,21 @@ class rvm::passenger::apache::centos::post(
   $gempath,
   $binpath
 ) {
+
+  if $version > '4.0.0' {
+    $install_out_directory = 'buildout'
+  } elsif $version > '3.9.0' {
+    $install_out_directory = 'libout'
+  }  else {
+    $install_out_directory = 'ext'
+  }
+
+  $install_creates = "${rvm::passenger::apache::gempath}/passenger-${rvm::passenger::apache::version}/${install_out_directory}/apache2/mod_passenger.so"
+
   exec {
     'passenger-install-apache2-module':
       command   => "${rvm::passenger::apache::binpath}rvm ${rvm::passenger::apache::ruby_version} exec passenger-install-apache2-module -a",
-      creates   => "${rvm::passenger::apache::gempath}/passenger-${rvm::passenger::apache::version}/ext/apache2/mod_passenger.so",
+      creates   => $install_creates,
       logoutput => 'on_failure',
       require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
   }

--- a/templates/passenger-apache-centos.conf.erb
+++ b/templates/passenger-apache-centos.conf.erb
@@ -1,8 +1,4 @@
-<% if version >= '3.9.0' %>
-LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/libout/apache2/mod_passenger.so
-<% else %>
-LoadModule passenger_module <%= @gempath %>/passenger-<%= @version %>/ext/apache2/mod_passenger.so
-<% end %>
+LoadModule passenger_module <%= @install_creates %>
 
 <IfModule passenger_module>
   PassengerRoot <%= @gempath %>/passenger-<%= @version %>


### PR DESCRIPTION
passenger now installs mod_passenger.so to the buildout directory. This version should work for this, and also retain the old locations for older versions
