### PR TITLE
cURL-s the correct URL for rvm-installer ...

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -8,7 +8,7 @@ class rvm::system($version=undef) {
 
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',
-    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
+    command => "bash -c '/usr/bin/curl -s -L https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
                 chmod +x /tmp/rvm-installer && \
                 rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${actual_version} && \
                 rm /tmp/rvm-installer'",


### PR DESCRIPTION
 and will follow redirects in the future.
# Overview

In March, Github moved raw.github.com to raw.githubusercontent.com, and redirected the old path to the new.  Because cURL does not follow redirects by default, this module was failing.  This change corrects the path and will follow redirects in the future, in case Github updates the subdomain again.
