### PR TITLE
new rvm installer location, follow redirects

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -8,7 +8,7 @@ class rvm::system($version=undef) {
 
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',
-    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
+    command => "/usr/bin/curl -s -L https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
                 chmod +x /tmp/rvm-installer && \
                 rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${actual_version} && \
                 rm /tmp/rvm-installer'",


### PR DESCRIPTION
The old location redirects to this one, but there wasn't a "-L" for curl to follow redirects,causing this command to silently fail.
