### PR TITLE
make curl follow http redirects

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -8,7 +8,7 @@ class rvm::system($version=undef) {
 
   exec { 'system-rvm':
     path    => '/usr/bin:/usr/sbin:/bin',
-    command => "bash -c '/usr/bin/curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
+    command => "bash -c '/usr/bin/curl -L -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer -o /tmp/rvm-installer && \
                 chmod +x /tmp/rvm-installer && \
                 rvm_bin_path=/usr/local/rvm/bin rvm_man_path=/usr/local/rvm/man /tmp/rvm-installer --version ${actual_version} && \
                 rm /tmp/rvm-installer'",


### PR DESCRIPTION
rvm installer has changed it's location and without this argument, curl won't follow the redirect
